### PR TITLE
Remove temporary debug prints from httpserver module.

### DIFF
--- a/modules/httpserver/module.go
+++ b/modules/httpserver/module.go
@@ -664,9 +664,6 @@ func (m *HTTPServerModule) wrapHandlerWithRequestEvents(handler http.Handler) ht
 		}, nil)
 		// Request events should be delivered synchronously; set hint via a background context to avoid cancellation
 		if emitErr := m.EmitEvent(modular.WithSynchronousNotification(r.Context()), requestReceivedEvent); emitErr != nil {
-			// Temporary diagnostic to understand why events may not be observed in tests
-			//nolint:forbidigo
-			fmt.Println("[httpserver] DEBUG: failed to emit request.received:", emitErr)
 			if m.logger != nil {
 				m.logger.Debug("Failed to emit request received event", "error", emitErr)
 			}
@@ -695,8 +692,6 @@ func (m *HTTPServerModule) wrapHandlerWithRequestEvents(handler http.Handler) ht
 		}, nil)
 		// Request events should be delivered synchronously; set hint via a background context to avoid cancellation
 		if emitErr := m.EmitEvent(modular.WithSynchronousNotification(r.Context()), requestHandledEvent); emitErr != nil {
-			//nolint:forbidigo
-			fmt.Println("[httpserver] DEBUG: failed to emit request.handled:", emitErr)
 			if m.logger != nil {
 				m.logger.Debug("Failed to emit request handled event", "error", emitErr)
 			}


### PR DESCRIPTION
## Summary
Removes temporary debug print statements that were added to the `httpserver` module for diagnostic purposes. These `fmt.Println` statements were printing error messages when event emission failed during request handling.

## Changes
- Removed debug print statements from `wrapHandlerWithRequestEvents` method in `modules/httpserver/module.go`
- Cleaned up two instances of temporary diagnostic logging for request.received and request.handled event emission failures
- Maintained existing proper error logging through the module's logger

## Rationale
The temporary debug prints were likely added for troubleshooting event emission issues in tests but are no longer needed and should not remain in production code.
