### PR TITLE
feat: Enhance contract extraction and comparison logic

### DIFF
--- a/.github/workflows/contract-check.yml
+++ b/.github/workflows/contract-check.yml
@@ -81,29 +81,39 @@ jobs:
         id: contract-diff
         run: |
           mkdir -p artifacts/diffs
-          
+
           breaking_changes=false
           has_changes=false
-          
+
           # Compare core framework
           if [ -f "artifacts/contracts/main/core.json" ] && [ -f "artifacts/contracts/pr/core.json" ]; then
             echo "Comparing core framework contract..."
-            if ./cmd/modcli/modcli contract compare artifacts/contracts/main/core.json artifacts/contracts/pr/core.json -o artifacts/diffs/core.json --format=markdown > artifacts/diffs/core.md 2>/dev/null; then
-              echo "Core framework: No breaking changes"
+            if ./cmd/modcli/modcli contract compare artifacts/contracts/main/core.json artifacts/contracts/pr/core.json -o artifacts/diffs/core.json --format=markdown > artifacts/diffs/core.md 2>&1; then
+              if [ -s "artifacts/diffs/core.md" ]; then
+                echo "Core framework: Changes detected (no breaking changes)"
+                has_changes=true
+              else
+                echo "Core framework: No changes"
+              fi
             else
               echo "Core framework: Breaking changes detected!"
               breaking_changes=true
               has_changes=true
             fi
           fi
-          
+
           # Compare all modules
           for module_dir in modules/*/; do
             module_name=$(basename "$module_dir")
             if [ -f "artifacts/contracts/main/${module_name}.json" ] && [ -f "artifacts/contracts/pr/${module_name}.json" ]; then
               echo "Comparing module: $module_name"
-              if ./cmd/modcli/modcli contract compare "artifacts/contracts/main/${module_name}.json" "artifacts/contracts/pr/${module_name}.json" -o "artifacts/diffs/${module_name}.json" --format=markdown > "artifacts/diffs/${module_name}.md" 2>/dev/null; then
-                echo "Module $module_name: No breaking changes"
+              if ./cmd/modcli/modcli contract compare "artifacts/contracts/main/${module_name}.json" "artifacts/contracts/pr/${module_name}.json" -o "artifacts/diffs/${module_name}.json" --format=markdown > "artifacts/diffs/${module_name}.md" 2>&1; then
+                if [ -s "artifacts/diffs/${module_name}.md" ]; then
+                  echo "Module $module_name: Changes detected (no breaking changes)"
+                  has_changes=true
+                else
+                  echo "Module $module_name: No changes"
+                fi
               else
                 echo "Module $module_name: Breaking changes detected!"
                 breaking_changes=true
@@ -111,7 +121,7 @@ jobs:
               fi
             fi
           done
-          
+
           echo "breaking_changes=$breaking_changes" >> $GITHUB_OUTPUT
           echo "has_changes=$has_changes" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -167,28 +167,67 @@ jobs:
           fi
 
           mkdir -p artifacts/contracts/prev artifacts/contracts/current artifacts/diffs
+
+          # Extract current contract (must succeed)
+          echo "Extracting current contract for ${MODULE}..."
+          if ! ./cmd/modcli/modcli contract extract modules/${MODULE} -o artifacts/contracts/current/${MODULE}.json 2>&1; then
+            echo "ERROR: Failed to extract current contract for ${MODULE}"
+            exit 1
+          fi
+          echo "✓ Current contract extracted successfully"
+
+          # Extract previous contract if tag exists
           if [ -n "$PREV_CONTRACT_REF" ]; then
+            echo "Extracting previous contract from ${PREV_CONTRACT_REF}..."
             TMPDIR=$(mktemp -d)
+            trap "rm -rf '$TMPDIR'" EXIT
+
+            # Extract source from previous tag
             git archive $PREV_CONTRACT_REF | tar -x -C "$TMPDIR"
-            mkdir -p "$TMPDIR/cmd/modcli" && cp cmd/modcli/modcli "$TMPDIR/cmd/modcli/modcli" || true
-            (cd "$TMPDIR/modules/${MODULE}" && ../../cmd/modcli/modcli contract extract . -o contract.json) || echo "Prev contract extraction failed"
-            if [ -f "$TMPDIR/modules/${MODULE}/contract.json" ]; then
-              mv "$TMPDIR/modules/${MODULE}/contract.json" artifacts/contracts/prev/${MODULE}.json
+
+            # Copy current modcli binary to temp dir
+            mkdir -p "$TMPDIR/cmd/modcli" && cp cmd/modcli/modcli "$TMPDIR/cmd/modcli/modcli"
+
+            # Extract contract from previous version using fixed modcli
+            if (cd "$TMPDIR" && ./cmd/modcli/modcli contract extract modules/${MODULE} -o prev-contract.json 2>&1); then
+              mv "$TMPDIR/prev-contract.json" artifacts/contracts/prev/${MODULE}.json
+              echo "✓ Previous contract extracted from $PREV_CONTRACT_REF"
+            else
+              echo "⚠ WARNING: Failed to extract contract from $PREV_CONTRACT_REF - treating as new module"
             fi
           fi
-          ./cmd/modcli/modcli contract extract modules/${MODULE} -o artifacts/contracts/current/${MODULE}.json || echo "Current contract extraction failed"
 
           CHANGE_CLASS="none"
           DIFF_MD_PATH="artifacts/diffs/${MODULE}.md"
+
           if [ -f artifacts/contracts/prev/${MODULE}.json ] && [ -f artifacts/contracts/current/${MODULE}.json ]; then
-            if ./cmd/modcli/modcli contract compare artifacts/contracts/prev/${MODULE}.json artifacts/contracts/current/${MODULE}.json -o artifacts/diffs/${MODULE}.json --format=markdown > "$DIFF_MD_PATH" 2>/dev/null; then
-              if [ -s "$DIFF_MD_PATH" ]; then CHANGE_CLASS="minor"; fi
+            echo "Comparing contracts..."
+            if ./cmd/modcli/modcli contract compare artifacts/contracts/prev/${MODULE}.json artifacts/contracts/current/${MODULE}.json -o artifacts/diffs/${MODULE}.json --format=markdown > "$DIFF_MD_PATH" 2>&1; then
+              if [ -s "$DIFF_MD_PATH" ]; then
+                echo "✓ Additive changes detected (non-breaking)"
+                CHANGE_CLASS="minor"
+              else
+                echo "✓ No API changes detected"
+                CHANGE_CLASS="none"
+              fi
             else
-              echo "Breaking changes detected"; CHANGE_CLASS="major"; [ -s "$DIFF_MD_PATH" ] || echo "(Breaking changes; diff unavailable)" > "$DIFF_MD_PATH";
+              echo "⚠ Breaking changes detected!"
+              echo "Diff output:"
+              cat "$DIFF_MD_PATH" || true
+              CHANGE_CLASS="major"
+              [ -s "$DIFF_MD_PATH" ] || echo "⚠️ Breaking changes detected but diff unavailable" > "$DIFF_MD_PATH"
             fi
           else
-            if [ -f artifacts/contracts/current/${MODULE}.json ] && [ $(wc -c < artifacts/contracts/current/${MODULE}.json) -gt 20 ]; then CHANGE_CLASS="minor"; fi
+            # No previous contract - check if current has content
+            if [ -f artifacts/contracts/current/${MODULE}.json ] && [ $(wc -c < artifacts/contracts/current/${MODULE}.json) -gt 20 ]; then
+              echo "✓ No previous contract found - treating as initial public API"
+              CHANGE_CLASS="minor"
+            else
+              echo "⚠ No public API detected"
+              CHANGE_CLASS="none"
+            fi
           fi
+
           echo "Contract change classification: $CHANGE_CLASS"
 
           CUR=${BASE_VERSION#v}; MAJOR=${CUR%%.*}; REST=${CUR#*.}; MINOR=${REST%%.*}; PATCH=${CUR##*.}


### PR DESCRIPTION
This pull request improves the reliability and accuracy of contract extraction and comparison in the module release and contract check workflows. The main focus is on correctly handling local directory paths versus Go package import paths, ensuring that contract extraction works as expected for module directories, and enhancing the reporting of contract changes in CI workflows.

**Path handling improvements:**

* Updated logic in `runExtractContractWithFlags` and `runGitDiffContractWithFlags` in `cmd/modcli/cmd/contract.go` to correctly identify local directory paths, including those with path separators or existing as directories, preventing incorrect treatment as Go package imports. [[1]](diffhunk://#diff-f4374e442598450648af2dd64ab162cfb700dcea41e4499c23168f052b9a7c01L168-R186) [[2]](diffhunk://#diff-f4374e442598450648af2dd64ab162cfb700dcea41e4499c23168f052b9a7c01L499-R525)
* Added a comprehensive test `TestExtractCommand_PathHandling` in `cmd/modcli/cmd/contract_test.go` to verify that various path formats (relative, absolute, single directory names, paths with separators) are correctly handled as local directories.

**CI workflow enhancements:**

* Improved extraction and comparison logic in `.github/workflows/module-release.yml` to ensure contracts are reliably extracted from both current and previous versions, with clearer error handling and reporting. The workflow now uses a consistent modcli binary for extraction and provides more informative output for success, warnings, and errors.
* Enhanced contract comparison reporting in `.github/workflows/contract-check.yml` for both core framework and modules: now distinguishes between "no changes," "changes detected (no breaking changes)," and "breaking changes detected," and sets flags accordingly for CI status. [[1]](diffhunk://#diff-e7466e8d3fbe57b138490debffdf4f3e3954387eed9793e004b832a9b70dd8cbL91-R97) [[2]](diffhunk://#diff-e7466e8d3fbe57b138490debffdf4f3e3954387eed9793e004b832a9b70dd8cbL105-R116)