### PR TITLE
fix: prevent tenant config pollution via deep copy in file-based loader

### DIFF
--- a/modules/reverseproxy/file_based_tenant_test.go
+++ b/modules/reverseproxy/file_based_tenant_test.go
@@ -1,0 +1,259 @@
+package reverseproxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/CrisisTextLine/modular"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultipleTenantsSameBackendOverride_FileBasedLoader tests the edge case
+// using actual YAML files and FileBasedTenantConfigLoader to exactly reproduce
+// the production scenario described in GitHub issue #111.
+func TestMultipleTenantsSameBackendOverride_FileBasedLoader(t *testing.T) {
+	// Setup mock backend servers
+	globalBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"backend":"global","url":"` + r.Host + `"}`))
+	}))
+	defer globalBackend.Close()
+
+	tenant1Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"backend":"tenant1","url":"` + r.Host + `"}`))
+	}))
+	defer tenant1Backend.Close()
+
+	tenant2Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"backend":"tenant2","url":"` + r.Host + `"}`))
+	}))
+	defer tenant2Backend.Close()
+
+	// Create temporary directory for config files
+	tmpDir, err := os.MkdirTemp("", "reverseproxy-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create config directory for tenant configs
+	tenantConfigDir := filepath.Join(tmpDir, "tenants")
+	err = os.MkdirAll(tenantConfigDir, 0755)
+	require.NoError(t, err)
+
+	// Write global config file
+	globalConfigYAML := `
+reverseproxy:
+  backend_services:
+    api: ` + globalBackend.URL + `
+  default_backend: api
+  tenant_id_header: X-Affiliate-Id
+  require_tenant_id: true
+`
+	globalConfigPath := filepath.Join(tmpDir, "global.yaml")
+	err = os.WriteFile(globalConfigPath, []byte(globalConfigYAML), 0644)
+	require.NoError(t, err)
+
+	t.Logf("Global backend URL: %s", globalBackend.URL)
+	t.Logf("Tenant1 backend URL: %s", tenant1Backend.URL)
+	t.Logf("Tenant2 backend URL: %s", tenant2Backend.URL)
+
+	// Write tenant1 config file - overrides "api" backend
+	tenant1ConfigYAML := `
+reverseproxy:
+  backend_services:
+    api: ` + tenant1Backend.URL + `
+`
+	tenant1ConfigPath := filepath.Join(tenantConfigDir, "tenant1.yaml")
+	err = os.WriteFile(tenant1ConfigPath, []byte(tenant1ConfigYAML), 0644)
+	require.NoError(t, err)
+
+	// Write tenant2 config file - ALSO overrides "api" backend with DIFFERENT URL
+	tenant2ConfigYAML := `
+reverseproxy:
+  backend_services:
+    api: ` + tenant2Backend.URL + `
+`
+	tenant2ConfigPath := filepath.Join(tenantConfigDir, "tenant2.yaml")
+	err = os.WriteFile(tenant2ConfigPath, []byte(tenant2ConfigYAML), 0644)
+	require.NoError(t, err)
+
+	// Create a real application (not a mock)
+	// We need to provide a config provider for the global config
+	globalCfg := ProvideConfig()
+	app := modular.NewStdApplication(modular.NewIsolatedConfigProvider(globalCfg), NewMockLogger())
+
+	// Register the reverseproxy config section with IsolatedConfigProvider to prevent sharing
+	app.RegisterConfigSection("reverseproxy", modular.NewIsolatedConfigProvider(globalCfg))
+
+	// Register tenant service
+	tenantService := modular.NewStandardTenantService(app.Logger())
+	err = app.RegisterService("tenantService", tenantService)
+	require.NoError(t, err)
+
+	// Register file-based tenant config loader
+	tenantConfigLoader := modular.NewFileBasedTenantConfigLoader(modular.TenantConfigParams{
+		ConfigNameRegex: regexp.MustCompile(`^tenant\d+\.yaml$`),
+		ConfigDir:       tenantConfigDir,
+		ConfigFeeders:   []modular.Feeder{},
+	})
+	err = app.RegisterService("tenantConfigLoader", tenantConfigLoader)
+	require.NoError(t, err)
+
+	// Manually populate global config from the YAML file for testing
+	// In a real app, this would be done by the config feeders
+	globalRPCfg := globalCfg.(*ReverseProxyConfig)
+	globalRPCfg.BackendServices = map[string]string{
+		"api": globalBackend.URL,
+	}
+	globalRPCfg.DefaultBackend = "api"
+	globalRPCfg.TenantIDHeader = "X-Affiliate-Id"
+	globalRPCfg.RequireTenantID = true
+
+	// Create and register the reverseproxy module
+	rpModule := NewModule()
+	app.RegisterModule(rpModule)
+
+	// Register a test router
+	mockRouter := &testRouter{
+		routes: make(map[string]http.HandlerFunc),
+	}
+	err = app.RegisterService("router", mockRouter)
+	require.NoError(t, err)
+
+	// THIS IS THE KEY SEQUENCE FROM THE ISSUE:
+	// 1. Init() runs - reverseproxy.Init() completes with 0 tenants
+	t.Log("Step 1: Calling app.Init() - reverseproxy should initialize with 0 tenants")
+	err = app.Init()
+	require.NoError(t, err)
+
+	// 2. Between Init() and Start(), framework loads tenant configs
+	t.Log("Step 2: Loading tenant configurations from files")
+	err = tenantConfigLoader.LoadTenantConfigurations(app, tenantService)
+	require.NoError(t, err)
+
+	// Verify tenants were loaded
+	tenants := tenantService.GetTenants()
+	require.Len(t, tenants, 2, "Should have loaded 2 tenants")
+	t.Logf("Loaded tenants: %v", tenants)
+
+	// 3. Start() runs - should create tenant-specific proxies
+	t.Log("Step 3: Calling app.Start() - should create tenant proxies")
+	err = app.Start()
+	require.NoError(t, err)
+
+	// Now verify the proxies are correctly set up
+	t.Log("Step 4: Verifying tenant proxy configuration")
+
+	// Get the module to inspect its state
+	// The module is just rpModule - we already have direct access to it
+	modulePtr := rpModule
+	require.NotNil(t, modulePtr)
+
+	// Check tenant1 configuration
+	tenant1ID := modular.TenantID("tenant1")
+	tenant1Cfg, exists := modulePtr.tenants[tenant1ID]
+	require.True(t, exists, "Tenant1 config should exist")
+	require.NotNil(t, tenant1Cfg, "Tenant1 config should not be nil")
+	t.Logf("Tenant1 config backend URL: %s", tenant1Cfg.BackendServices["api"])
+	assert.Equal(t, tenant1Backend.URL, tenant1Cfg.BackendServices["api"],
+		"Tenant1 config should have tenant1's backend URL")
+
+	// Check tenant2 configuration
+	tenant2ID := modular.TenantID("tenant2")
+	tenant2Cfg, exists := modulePtr.tenants[tenant2ID]
+	require.True(t, exists, "Tenant2 config should exist")
+	require.NotNil(t, tenant2Cfg, "Tenant2 config should not be nil")
+	t.Logf("Tenant2 config backend URL: %s", tenant2Cfg.BackendServices["api"])
+	assert.Equal(t, tenant2Backend.URL, tenant2Cfg.BackendServices["api"],
+		"Tenant2 config should have tenant2's backend URL")
+
+	// Check tenant1 proxy
+	tenant1Proxies, exists := modulePtr.tenantBackendProxies[tenant1ID]
+	require.True(t, exists, "Tenant1 proxy map should exist")
+	require.NotNil(t, tenant1Proxies, "Tenant1 proxies should not be nil")
+
+	tenant1APIProxy, exists := tenant1Proxies["api"]
+	require.True(t, exists, "Tenant1 'api' proxy should exist")
+	require.NotNil(t, tenant1APIProxy, "Tenant1 'api' proxy should not be nil")
+	t.Logf("Tenant1 API proxy: %p", tenant1APIProxy)
+
+	// Check tenant2 proxy
+	tenant2Proxies, exists := modulePtr.tenantBackendProxies[tenant2ID]
+	require.True(t, exists, "Tenant2 proxy map should exist")
+	require.NotNil(t, tenant2Proxies, "Tenant2 proxies should not be nil")
+
+	tenant2APIProxy, exists := tenant2Proxies["api"]
+	require.True(t, exists, "Tenant2 'api' proxy should exist")
+	require.NotNil(t, tenant2APIProxy, "Tenant2 'api' proxy should not be nil")
+	t.Logf("Tenant2 API proxy: %p", tenant2APIProxy)
+
+	// The two proxies should be different instances
+	assert.NotEqual(t, tenant1APIProxy, tenant2APIProxy,
+		"Tenant1 and tenant2 proxies should be different instances")
+
+	// Step 5: Test actual requests through the proxies
+	t.Log("Step 5: Testing actual HTTP requests through tenant proxies")
+
+	// Test tenant1 request
+	tenant1Proxy, exists := modulePtr.getProxyForBackendAndTenant("api", tenant1ID)
+	require.True(t, exists, "Tenant1 proxy should be retrievable")
+	require.NotNil(t, tenant1Proxy, "Tenant1 proxy should not be nil")
+
+	tenant1Req := httptest.NewRequest("GET", "http://example.com/api/test", nil)
+	tenant1Req.Header.Set("X-Affiliate-Id", string(tenant1ID))
+	tenant1W := httptest.NewRecorder()
+	tenant1Proxy.ServeHTTP(tenant1W, tenant1Req)
+
+	tenant1Resp := tenant1W.Result()
+	assert.Equal(t, http.StatusOK, tenant1Resp.StatusCode)
+	tenant1Body, err := io.ReadAll(tenant1Resp.Body)
+	require.NoError(t, err)
+	t.Logf("Tenant1 response: %s", string(tenant1Body))
+
+	var tenant1Data map[string]interface{}
+	err = json.Unmarshal(tenant1Body, &tenant1Data)
+	require.NoError(t, err)
+
+	// CRITICAL ASSERTION: Tenant1 should get tenant1's backend
+	assert.Equal(t, "tenant1", tenant1Data["backend"],
+		"Request with tenant1 ID should route to tenant1's backend")
+
+	// Test tenant2 request
+	tenant2Proxy, exists := modulePtr.getProxyForBackendAndTenant("api", tenant2ID)
+	require.True(t, exists, "Tenant2 proxy should be retrievable")
+	require.NotNil(t, tenant2Proxy, "Tenant2 proxy should not be nil")
+
+	tenant2Req := httptest.NewRequest("GET", "http://example.com/api/test", nil)
+	tenant2Req.Header.Set("X-Affiliate-Id", string(tenant2ID))
+	tenant2W := httptest.NewRecorder()
+	tenant2Proxy.ServeHTTP(tenant2W, tenant2Req)
+
+	tenant2Resp := tenant2W.Result()
+	assert.Equal(t, http.StatusOK, tenant2Resp.StatusCode)
+	tenant2Body, err := io.ReadAll(tenant2Resp.Body)
+	require.NoError(t, err)
+	t.Logf("Tenant2 response: %s", string(tenant2Body))
+
+	var tenant2Data map[string]interface{}
+	err = json.Unmarshal(tenant2Body, &tenant2Data)
+	require.NoError(t, err)
+
+	// CRITICAL ASSERTION: Tenant2 should get tenant2's backend, NOT tenant1's
+	assert.Equal(t, "tenant2", tenant2Data["backend"],
+		"Request with tenant2 ID should route to tenant2's backend (NOT tenant1's backend)")
+
+	// Clean up
+	err = app.Stop()
+	require.NoError(t, err)
+}

--- a/modules/reverseproxy/module_test.go
+++ b/modules/reverseproxy/module_test.go
@@ -1173,6 +1173,358 @@ func TestTenantSpecificBackendProxiesCreated(t *testing.T) {
 		"Request with tenant ID should route to tenant-specific backend")
 }
 
+// TestMultipleTenantsSameBackendOverride tests the edge case where multiple tenants
+// override the SAME backend ID with different URLs.
+// This reproduces the edge case bug found in GitHub issue #111 comment.
+//
+// The bug: When multiple tenants override the same backend ID (e.g., "api") with
+// different URLs, both tenants end up with proxies pointing to the same URL due to
+// improper variable scoping/capture in the createTenantProxies() loop.
+//
+// Expected behavior: tenant1 requests → tenant1's backend, tenant2 requests → tenant2's backend
+// Actual buggy behavior: Both tenant1 and tenant2 requests → same backend (last processed tenant's URL)
+func TestMultipleTenantsSameBackendOverride(t *testing.T) {
+	// Setup mock backend servers
+	globalBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"backend":"global","url":"` + r.Host + `"}`))
+	}))
+	defer globalBackend.Close()
+
+	tenant1Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"backend":"tenant1","url":"` + r.Host + `"}`))
+	}))
+	defer tenant1Backend.Close()
+
+	tenant2Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"backend":"tenant2","url":"` + r.Host + `"}`))
+	}))
+	defer tenant2Backend.Close()
+
+	// Create module
+	module := NewModule()
+
+	// Create global config with a backend service
+	globalConfig := &ReverseProxyConfig{
+		BackendServices: map[string]string{
+			"api": globalBackend.URL,
+		},
+		DefaultBackend:  "api",
+		TenantIDHeader:  "X-Affiliate-Id",
+		RequireTenantID: true,
+		Routes: map[string]string{
+			"/api/*": "api",
+		},
+	}
+
+	// Create mock app with global config
+	mockApp := NewMockTenantApplication()
+	mockApp.configSections["reverseproxy"] = &mockConfigProvider{
+		config: globalConfig,
+	}
+
+	// Set up tenant1 configuration that overrides the "api" backend
+	tenant1ID := modular.TenantID("tenant1")
+	tenant1Config := &ReverseProxyConfig{
+		BackendServices: map[string]string{
+			"api": tenant1Backend.URL, // Override with tenant1-specific URL
+		},
+	}
+
+	// Register tenant1 config
+	err := mockApp.RegisterTenant(tenant1ID, map[string]modular.ConfigProvider{
+		"reverseproxy": NewStdConfigProvider(tenant1Config),
+	})
+	require.NoError(t, err)
+
+	// Set up tenant2 configuration that ALSO overrides the "api" backend
+	tenant2ID := modular.TenantID("tenant2")
+	tenant2Config := &ReverseProxyConfig{
+		BackendServices: map[string]string{
+			"api": tenant2Backend.URL, // Override with tenant2-specific URL (DIFFERENT from tenant1)
+		},
+	}
+
+	// Register tenant2 config
+	err = mockApp.RegisterTenant(tenant2ID, map[string]modular.ConfigProvider{
+		"reverseproxy": NewStdConfigProvider(tenant2Config),
+	})
+	require.NoError(t, err)
+
+	// Set up router service
+	mockRouter := &testRouter{
+		routes: make(map[string]http.HandlerFunc),
+	}
+
+	// Initialize proxy maps
+	module.tenants = make(map[modular.TenantID]*ReverseProxyConfig)
+	module.tenantBackendProxies = make(map[modular.TenantID]map[string]*httputil.ReverseProxy)
+	module.backendProxies = make(map[string]*httputil.ReverseProxy)
+	module.backendRoutes = make(map[string]map[string]http.HandlerFunc)
+	module.compositeRoutes = make(map[string]http.HandlerFunc)
+	module.router = mockRouter
+
+	// Initialize module FIRST
+	err = module.Init(mockApp)
+	require.NoError(t, err)
+
+	// Register tenants AFTER Init (simulating FileBasedTenantConfigLoader flow)
+	module.OnTenantRegistered(tenant1ID)
+	module.OnTenantRegistered(tenant2ID)
+
+	// Call Start() - this should create tenant-specific proxies for BOTH tenants
+	err = module.Start(context.Background())
+	require.NoError(t, err)
+
+	// Log the tenant configs and proxy URLs for debugging
+	t.Logf("Tenant1 config backend URL: %s", module.tenants[tenant1ID].BackendServices["api"])
+	t.Logf("Tenant2 config backend URL: %s", module.tenants[tenant2ID].BackendServices["api"])
+
+	// Verify tenant configs were merged
+	tenant1Cfg, exists := module.tenants[tenant1ID]
+	require.True(t, exists, "Tenant1 config should exist")
+	require.NotNil(t, tenant1Cfg, "Tenant1 config should not be nil")
+	assert.Equal(t, tenant1Backend.URL, tenant1Cfg.BackendServices["api"],
+		"Tenant1 config should have tenant1's backend URL")
+
+	tenant2Cfg, exists := module.tenants[tenant2ID]
+	require.True(t, exists, "Tenant2 config should exist")
+	require.NotNil(t, tenant2Cfg, "Tenant2 config should not be nil")
+	assert.Equal(t, tenant2Backend.URL, tenant2Cfg.BackendServices["api"],
+		"Tenant2 config should have tenant2's backend URL")
+
+	// Verify tenant-specific proxies exist
+	tenant1Proxies, exists := module.tenantBackendProxies[tenant1ID]
+	require.True(t, exists, "Tenant1 proxy map should exist")
+	require.NotNil(t, tenant1Proxies, "Tenant1 proxies should not be nil")
+
+	tenant2Proxies, exists := module.tenantBackendProxies[tenant2ID]
+	require.True(t, exists, "Tenant2 proxy map should exist")
+	require.NotNil(t, tenant2Proxies, "Tenant2 proxies should not be nil")
+
+	// Verify each tenant has an "api" proxy
+	tenant1APIProxy, exists := tenant1Proxies["api"]
+	require.True(t, exists, "Tenant1 'api' proxy should exist")
+	require.NotNil(t, tenant1APIProxy, "Tenant1 'api' proxy should not be nil")
+
+	tenant2APIProxy, exists := tenant2Proxies["api"]
+	require.True(t, exists, "Tenant2 'api' proxy should exist")
+	require.NotNil(t, tenant2APIProxy, "Tenant2 'api' proxy should not be nil")
+
+	// Log proxy details for debugging
+	if tenant1APIProxy != nil {
+		t.Logf("Tenant1 proxy Director: %p", tenant1APIProxy)
+	}
+	if tenant2APIProxy != nil {
+		t.Logf("Tenant2 proxy Director: %p", tenant2APIProxy)
+	}
+
+	// The two tenant proxies should be different instances
+	assert.NotEqual(t, tenant1APIProxy, tenant2APIProxy,
+		"Tenant1 and tenant2 proxies should be different instances")
+
+	// Create a test handler that uses the actual routing logic from the module
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		tenantIDStr := r.Header.Get("X-Affiliate-Id")
+		tenantID := modular.TenantID(tenantIDStr)
+
+		proxy, exists := module.getProxyForBackendAndTenant("api", tenantID)
+		if !exists {
+			http.Error(w, "Backend not found", http.StatusNotFound)
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	}
+
+	// Test request with tenant1 header
+	tenant1Req := httptest.NewRequest("GET", "http://example.com/api/test", nil)
+	tenant1Req.Header.Set("X-Affiliate-Id", string(tenant1ID))
+	tenant1W := httptest.NewRecorder()
+	testHandler(tenant1W, tenant1Req)
+
+	tenant1Resp := tenant1W.Result()
+	assert.Equal(t, http.StatusOK, tenant1Resp.StatusCode)
+	tenant1Body, err := io.ReadAll(tenant1Resp.Body)
+	require.NoError(t, err)
+
+	t.Logf("Tenant1 response: %s", string(tenant1Body))
+
+	var tenant1Data map[string]interface{}
+	err = json.Unmarshal(tenant1Body, &tenant1Data)
+	require.NoError(t, err)
+
+	// THIS IS THE KEY ASSERTION: Tenant1 should get tenant1's backend
+	assert.Equal(t, "tenant1", tenant1Data["backend"],
+		"Request with tenant1 ID should route to tenant1's backend")
+
+	// Test request with tenant2 header
+	tenant2Req := httptest.NewRequest("GET", "http://example.com/api/test", nil)
+	tenant2Req.Header.Set("X-Affiliate-Id", string(tenant2ID))
+	tenant2W := httptest.NewRecorder()
+	testHandler(tenant2W, tenant2Req)
+
+	tenant2Resp := tenant2W.Result()
+	assert.Equal(t, http.StatusOK, tenant2Resp.StatusCode)
+	tenant2Body, err := io.ReadAll(tenant2Resp.Body)
+	require.NoError(t, err)
+
+	t.Logf("Tenant2 response: %s", string(tenant2Body))
+
+	var tenant2Data map[string]interface{}
+	err = json.Unmarshal(tenant2Body, &tenant2Data)
+	require.NoError(t, err)
+
+	// THIS IS THE BUG CHECK: Tenant2 should get tenant2's backend, NOT tenant1's
+	assert.Equal(t, "tenant2", tenant2Data["backend"],
+		"Request with tenant2 ID should route to tenant2's backend (NOT tenant1's backend)")
+
+	// If the bug exists, both tenants will route to the same backend (the last tenant processed)
+	// The test will fail with a message like:
+	// "Request with tenant1 ID should route to tenant1's backend" but got "tenant2"
+}
+
+// TestMultipleTenantsSameBackendOverride_Concurrent tests the edge case with concurrent
+// requests to ensure proper proxy isolation under concurrent load.
+// This runs the multi-tenant backend override test multiple times to catch race conditions.
+func TestMultipleTenantsSameBackendOverride_Concurrent(t *testing.T) {
+	const iterations = 20
+
+	for i := 0; i < iterations; i++ {
+		t.Run(fmt.Sprintf("Iteration_%d", i), func(t *testing.T) {
+			t.Parallel() // Run iterations in parallel to stress test
+
+			// Setup mock backend servers
+			globalBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"backend":"global"}`))
+			}))
+			defer globalBackend.Close()
+
+			tenant1Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"backend":"tenant1"}`))
+			}))
+			defer tenant1Backend.Close()
+
+			tenant2Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"backend":"tenant2"}`))
+			}))
+			defer tenant2Backend.Close()
+
+			tenant3Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"backend":"tenant3"}`))
+			}))
+			defer tenant3Backend.Close()
+
+			// Create module
+			module := NewModule()
+
+			// Create global config
+			globalConfig := &ReverseProxyConfig{
+				BackendServices: map[string]string{
+					"api": globalBackend.URL,
+				},
+				DefaultBackend:  "api",
+				TenantIDHeader:  "X-Affiliate-Id",
+				RequireTenantID: true,
+			}
+
+			// Create mock app
+			mockApp := NewMockTenantApplication()
+			mockApp.configSections["reverseproxy"] = &mockConfigProvider{config: globalConfig}
+
+			// Register 3 tenants with different backend URLs for the SAME backend ID
+			tenants := []struct {
+				id  modular.TenantID
+				url string
+			}{
+				{"tenant1", tenant1Backend.URL},
+				{"tenant2", tenant2Backend.URL},
+				{"tenant3", tenant3Backend.URL},
+			}
+
+			for _, tenant := range tenants {
+				err := mockApp.RegisterTenant(tenant.id, map[string]modular.ConfigProvider{
+					"reverseproxy": NewStdConfigProvider(&ReverseProxyConfig{
+						BackendServices: map[string]string{
+							"api": tenant.url,
+						},
+					}),
+				})
+				require.NoError(t, err)
+			}
+
+			// Setup module
+			mockRouter := &testRouter{routes: make(map[string]http.HandlerFunc)}
+			module.tenants = make(map[modular.TenantID]*ReverseProxyConfig)
+			module.tenantBackendProxies = make(map[modular.TenantID]map[string]*httputil.ReverseProxy)
+			module.backendProxies = make(map[string]*httputil.ReverseProxy)
+			module.backendRoutes = make(map[string]map[string]http.HandlerFunc)
+			module.compositeRoutes = make(map[string]http.HandlerFunc)
+			module.router = mockRouter
+
+			// Init, register tenants, and start
+			err := module.Init(mockApp)
+			require.NoError(t, err)
+
+			for _, tenant := range tenants {
+				module.OnTenantRegistered(tenant.id)
+			}
+
+			err = module.Start(context.Background())
+			require.NoError(t, err)
+
+			// Test each tenant concurrently
+			var wg sync.WaitGroup
+			for _, tenant := range tenants {
+				wg.Add(1)
+				go func(tid modular.TenantID, expectedBackend string) {
+					defer wg.Done()
+
+					// Make multiple requests per tenant
+					for j := 0; j < 5; j++ {
+						proxy, exists := module.getProxyForBackendAndTenant("api", tid)
+						require.True(t, exists, "Proxy should exist for tenant %s", tid)
+						require.NotNil(t, proxy, "Proxy should not be nil for tenant %s", tid)
+
+						// Test actual request
+						req := httptest.NewRequest("GET", "http://example.com/api/test", nil)
+						req.Header.Set("X-Affiliate-Id", string(tid))
+						w := httptest.NewRecorder()
+
+						proxy.ServeHTTP(w, req)
+
+						resp := w.Result()
+						body, err := io.ReadAll(resp.Body)
+						require.NoError(t, err)
+
+						var data map[string]interface{}
+						err = json.Unmarshal(body, &data)
+						require.NoError(t, err)
+
+						// Critical assertion: Each tenant must get its own backend
+						assert.Equal(t, expectedBackend, data["backend"],
+							"Tenant %s request %d should route to %s backend", tid, j, expectedBackend)
+					}
+				}(tenant.id, string(tenant.id))
+			}
+
+			wg.Wait()
+		})
+	}
+}
+
 // TestSetupResponseCacheWithTenantOverrides tests that cache is initialized
 // when any tenant has caching enabled, even if global caching is disabled
 func TestSetupResponseCacheWithTenantOverrides(t *testing.T) {


### PR DESCRIPTION
Fixes multi-tenant backend override bug where multiple tenants overriding the same backend ID with different URLs would end up sharing the same backend due to shallow copying of map references.

Root cause: The FileBasedTenantConfigLoader was using shallow copies when preparing tenant configs, causing all tenants to share the same BackendServices map reference. When tenant2's config was loaded, it would overwrite values in the shared map, polluting tenant1's config.

Changes:
- tenant_config_file_loader.go:
  * Use createTempConfigDeep() instead of createTempConfig() for proper map/slice isolation during config preparation
  * Replace shallow dstField.Set() with deepCopyValue() in copyStructToStruct() and setFieldValue() functions
  * Use IsolatedConfigProvider instead of StdConfigProvider to ensure each GetConfig() call returns a fresh deep copy

- modules/reverseproxy/file_based_tenant_test.go:
  * Add comprehensive test using actual YAML files and FileBasedTenantConfigLoader to reproduce the exact production scenario
  * Test verifies tenant1 and tenant2 can override the same backend ID ("api") with different URLs without config pollution

- modules/reverseproxy/module_test.go:
  * Add TestMultipleTenantsSameBackendOverride to test the edge case with mock-based setup
  * Add TestMultipleTenantsSameBackendOverride_Concurrent for stress testing with 20 parallel iterations

Why existing tests didn't catch this:
Mock-based tests created fresh config objects per tenant, bypassing the shared state issue that only manifests when using FileBasedTenantConfigLoader with the real config loading pipeline.

Related: GitHub issue #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)