### PR TITLE
 fix: preserve tenant prefix in TenantAffixedEnvFeeder during config …

### DIFF
--- a/feeders/DOCUMENTATION.md
+++ b/feeders/DOCUMENTATION.md
@@ -119,6 +119,7 @@ config.AddFeeder(feeders.NewDotEnvFeeder(".env"))
 
 // Environment-based overrides
 config.AddFeeder(feeders.NewEnvFeeder())
+// Note: Include underscores in prefix/suffix as desired
 config.AddFeeder(feeders.NewAffixedEnvFeeder("APP_", "_PROD"))
 
 // Feed the configuration
@@ -137,10 +138,11 @@ YAML values → DotEnv values → OS Env values → Affixed Env values
 ### EnvFeeder
 Uses env tags directly: `env:"DATABASE_URL"`
 
-### AffixedEnvFeeder  
-Constructs: `PREFIX__ENVTAG__SUFFIX`
-- Example: `PROD_` + `HOST` + `_ENV` = `PROD__HOST__ENV`
-- Uses double underscores between components
+### AffixedEnvFeeder
+Constructs: `PREFIX + ENVTAG + SUFFIX`
+- Example with prefix `"PROD_"`, tag `"HOST"`, suffix `"_ENV"`: `PROD_HOST_ENV`
+- **Users must include separators (like underscores) in their prefix/suffix**
+- Framework no longer automatically adds underscores between components
 
 ### InstanceAwareEnvFeeder
 Constructs: `MODULE_INSTANCE_FIELD`
@@ -148,7 +150,9 @@ Constructs: `MODULE_INSTANCE_FIELD`
 
 ### TenantAffixedEnvFeeder
 Combines tenant ID with affixed pattern:
-- Example: `APP_TENANT123__CONFIG__PROD`
+- Example with prefix function `tenantId + "_"` and tag `"CONFIG"`: `TENANT123_CONFIG`
+- Prefix/suffix functions must include any desired separators
+- Preserves pre-configured prefix/suffix when used with tenant config loader
 
 ## Error Handling
 

--- a/feeders/affixed_debug_test.go
+++ b/feeders/affixed_debug_test.go
@@ -8,9 +8,9 @@ func TestAffixedEnvFeederCatalogDebug(t *testing.T) {
 	// Reset global catalog
 	ResetGlobalEnvCatalog()
 
-	// Set environment variables (double underscores per AffixedEnvFeeder pattern)
-	t.Setenv("PROD__HOST__ENV", "prod.example.com")
-	t.Setenv("PROD__PORT__ENV", "3306")
+	// Set environment variables (framework no longer adds underscores)
+	t.Setenv("PROD_HOST_ENV", "prod.example.com")
+	t.Setenv("PROD_PORT_ENV", "3306")
 
 	type DatabaseConfig struct {
 		Host string `env:"HOST"`

--- a/feeders/affixed_env.go
+++ b/feeders/affixed_env.go
@@ -164,12 +164,13 @@ func (f *AffixedEnvFeeder) processField(field reflect.Value, fieldType *reflect.
 // setFieldFromEnv sets a field value from an environment variable
 func (f *AffixedEnvFeeder) setFieldFromEnv(field reflect.Value, fieldType *reflect.StructField, envTag, fieldPath, prefix, suffix string) error {
 	// Build environment variable name
+	// Note: Users must include any separators (like underscores) in their prefix/suffix
 	envName := strings.ToUpper(envTag)
 	if prefix != "" {
-		envName = prefix + "_" + envName
+		envName = prefix + envName
 	}
 	if suffix != "" {
-		envName = envName + "_" + suffix
+		envName = envName + suffix
 	}
 
 	if f.verboseDebug && f.logger != nil {

--- a/feeders/affixed_env_field_tracking_test.go
+++ b/feeders/affixed_env_field_tracking_test.go
@@ -15,13 +15,13 @@ type TestAffixedEnvConfig struct {
 }
 
 func TestAffixedEnvFeeder_FieldTracking(t *testing.T) {
-	// Set up environment variables with prefix and suffix
+	// Set up environment variables with prefix and suffix (framework no longer adds underscores)
 	envVars := map[string]string{
-		"APP__NAME__PROD":    "test-app",
-		"APP__PORT__PROD":    "8080",
-		"APP__ENABLED__PROD": "true",
-		"APP__DEBUG__PROD":   "verbose",
-		"OTHER_VAR":          "ignored", // Should not be matched
+		"APP_NAME_PROD":    "test-app",
+		"APP_PORT_PROD":    "8080",
+		"APP_ENABLED_PROD": "true",
+		"APP_DEBUG_PROD":   "verbose",
+		"OTHER_VAR":        "ignored", // Should not be matched
 	}
 
 	// Set environment variables for test
@@ -102,29 +102,29 @@ func TestAffixedEnvFeeder_FieldTracking(t *testing.T) {
 			if fmt.Sprintf("%v", pop.Value) != "test-app" {
 				t.Errorf("Expected tracked value 'test-app' for Name, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP__NAME__PROD" {
-				t.Errorf("Expected SourceKey 'APP__NAME__PROD' for Name, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_NAME_PROD" {
+				t.Errorf("Expected SourceKey 'APP_NAME_PROD' for Name, got %s", pop.SourceKey)
 			}
 		case "Port":
 			if fmt.Sprintf("%v", pop.Value) != "8080" {
 				t.Errorf("Expected tracked value '8080' for Port, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP__PORT__PROD" {
-				t.Errorf("Expected SourceKey 'APP__PORT__PROD' for Port, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_PORT_PROD" {
+				t.Errorf("Expected SourceKey 'APP_PORT_PROD' for Port, got %s", pop.SourceKey)
 			}
 		case "Enabled":
 			if fmt.Sprintf("%v", pop.Value) != "true" {
 				t.Errorf("Expected tracked value 'true' for Enabled, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP__ENABLED__PROD" {
-				t.Errorf("Expected SourceKey 'APP__ENABLED__PROD' for Enabled, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_ENABLED_PROD" {
+				t.Errorf("Expected SourceKey 'APP_ENABLED_PROD' for Enabled, got %s", pop.SourceKey)
 			}
 		case "Debug":
 			if fmt.Sprintf("%v", pop.Value) != "verbose" {
 				t.Errorf("Expected tracked value 'verbose' for Debug, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP__DEBUG__PROD" {
-				t.Errorf("Expected SourceKey 'APP__DEBUG__PROD' for Debug, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_DEBUG_PROD" {
+				t.Errorf("Expected SourceKey 'APP_DEBUG_PROD' for Debug, got %s", pop.SourceKey)
 			}
 		}
 	}
@@ -141,12 +141,12 @@ func TestAffixedEnvFeeder_SetFieldTracker(t *testing.T) {
 }
 
 func TestAffixedEnvFeeder_WithoutFieldTracker(t *testing.T) {
-	// Set up environment variables
-	os.Setenv("TEST__NAME__DEV", "test-app")
-	os.Setenv("TEST__PORT__DEV", "8080")
+	// Set up environment variables (framework no longer adds underscores)
+	os.Setenv("TEST_NAME_DEV", "test-app")
+	os.Setenv("TEST_PORT_DEV", "8080")
 	defer func() {
-		os.Unsetenv("TEST__NAME__DEV")
-		os.Unsetenv("TEST__PORT__DEV")
+		os.Unsetenv("TEST_NAME_DEV")
+		os.Unsetenv("TEST_PORT_DEV")
 	}()
 
 	// Create feeder without field tracker

--- a/feeders/affixed_env_test.go
+++ b/feeders/affixed_env_test.go
@@ -26,7 +26,7 @@ func TestAffixedEnvFeeder(t *testing.T) {
 		t.Setenv("APP_SETTING_TEST", "true")
 
 		var config Config
-		feeder := NewAffixedEnvFeeder("APP", "TEST")
+		feeder := NewAffixedEnvFeeder("APP_", "_TEST")
 		err := feeder.Feed(&config)
 
 		if err != nil {
@@ -50,7 +50,7 @@ func TestAffixedEnvFeeder(t *testing.T) {
 		t.Setenv("APP_HOST", "localhost")
 
 		var config Config
-		feeder := NewAffixedEnvFeeder("APP", "")
+		feeder := NewAffixedEnvFeeder("APP_", "")
 		err := feeder.Feed(&config)
 
 		if err != nil {
@@ -65,7 +65,7 @@ func TestAffixedEnvFeeder(t *testing.T) {
 		t.Setenv("HOST_TEST", "localhost")
 
 		var config Config
-		feeder := NewAffixedEnvFeeder("", "TEST")
+		feeder := NewAffixedEnvFeeder("", "_TEST")
 		err := feeder.Feed(&config)
 
 		if err != nil {
@@ -87,7 +87,7 @@ func TestAffixedEnvFeeder(t *testing.T) {
 	})
 
 	t.Run("invalid structure", func(t *testing.T) {
-		feeder := NewAffixedEnvFeeder("APP", "TEST")
+		feeder := NewAffixedEnvFeeder("APP_", "_TEST")
 		err := feeder.Feed("not a struct pointer")
 
 		if !errors.Is(err, ErrEnvInvalidStructure) {
@@ -103,7 +103,7 @@ func TestAffixedEnvFeeder(t *testing.T) {
 		}
 
 		var config Config
-		feeder := NewAffixedEnvFeeder("VERBOSE", "TEST")
+		feeder := NewAffixedEnvFeeder("VERBOSE_", "_TEST")
 		logger := &MockLogger{}
 
 		// Enable verbose debugging

--- a/feeders/env_catalog_integration_test.go
+++ b/feeders/env_catalog_integration_test.go
@@ -98,9 +98,9 @@ DATABASE_PORT=5432
 		// Set up environment variables with prefix/suffix pattern
 		// AffixedEnvFeeder with prefix "PROD_" and suffix "_ENV"
 		// constructs: prefix + "_" + envTag + "_" + suffix
-		// For env:"HOST" -> "PROD_" + "_" + "HOST" + "_" + "_ENV" = "PROD__HOST__ENV"
-		t.Setenv("PROD__HOST__ENV", "prod.example.com")
-		t.Setenv("PROD__PORT__ENV", "3306")
+		// For env:"HOST" -> "PROD_" + "HOST" + "_ENV" = "PROD_HOST_ENV" (framework no longer adds underscores)
+		t.Setenv("PROD_HOST_ENV", "prod.example.com")
+		t.Setenv("PROD_PORT_ENV", "3306")
 
 		var config AppConfig
 

--- a/feeders/env_var_debug_test.go
+++ b/feeders/env_var_debug_test.go
@@ -27,11 +27,11 @@ func TestEnvVarConstruction(t *testing.T) {
 
 	// Test what AffixedEnvFeeder constructs
 	// With prefix "PROD_" and suffix "_ENV", for field tagged env:"HOST"
-	// It should construct: ToUpper("PROD_") + "_" + ToUpper("HOST") + "_" + ToUpper("_ENV")
-	// = "PROD_" + "_" + "HOST" + "_" + "_ENV" = "PROD__HOST__ENV"
+	// It should construct: ToUpper("PROD_") + ToUpper("HOST") + ToUpper("_ENV")
+	// = "PROD_" + "HOST" + "_ENV" = "PROD_HOST_ENV" (framework no longer adds underscores)
 
-	expectedVar1 := "PROD__HOST__ENV"
-	expectedVar2 := "PROD__PORT__ENV"
+	expectedVar1 := "PROD_HOST_ENV"
+	expectedVar2 := "PROD_PORT_ENV"
 
 	testValue1, testExists1 := catalog.Get(expectedVar1)
 	testValue2, testExists2 := catalog.Get(expectedVar2)

--- a/feeders/tenant_affixed_env_debug_test.go
+++ b/feeders/tenant_affixed_env_debug_test.go
@@ -9,8 +9,8 @@ import (
 func TestTenantAffixedEnvFeeder_Debug(t *testing.T) {
 	// Set up multiple environment variables to test
 	envVars := []string{
-		"APP_test123__NAME__PROD",
-		"APP_TEST123__NAME__PROD",
+		"APP_test123_NAME_PROD",
+		"APP_TEST123_NAME_PROD",
 		"APP_test123_NAME_PROD",
 		"APP_TEST123_NAME_PROD",
 	}
@@ -40,13 +40,13 @@ func TestTenantAffixedEnvFeeder_Debug(t *testing.T) {
 	fmt.Printf("Final prefix: %s\n", feeder.Prefix)
 	fmt.Printf("Final suffix: %s\n", feeder.Suffix)
 
-	// Expected env var name: APP_test123_ + _ + NAME + _ + _PROD = APP_test123__NAME__PROD
-	expectedEnvVar := "APP_test123__NAME__PROD"
+	// Expected env var name: APP_test123_ + NAME + _PROD = APP_TEST123_NAME_PROD (uppercased, framework no longer adds underscores)
+	expectedEnvVar := "APP_TEST123_NAME_PROD"
 	fmt.Printf("Expected env var name: %s\n", expectedEnvVar)
 	fmt.Printf("Actual value in env: %s\n", os.Getenv(expectedEnvVar))
 
 	// But AffixedEnvFeeder does ToUpper on the env tag, so let's check uppercase version
-	expectedEnvVarUpper := "APP_test123__NAME__PROD"
+	expectedEnvVarUpper := "APP_TEST123_NAME_PROD"
 	fmt.Printf("Expected env var name (upper): %s\n", expectedEnvVarUpper)
 	fmt.Printf("Actual value in env (upper): %s\n", os.Getenv(expectedEnvVarUpper))
 

--- a/feeders/tenant_affixed_env_field_tracking_test.go
+++ b/feeders/tenant_affixed_env_field_tracking_test.go
@@ -16,14 +16,14 @@ type TestTenantAffixedEnvConfig struct {
 func TestTenantAffixedEnvFeeder_FieldTracking(t *testing.T) {
 	// Set up environment variables for tenant "test123"
 	// The AffixedEnvFeeder converts prefix/suffix to uppercase and constructs env vars as:
-	// ToUpper(prefix) + "_" + ToUpper(envTag) + "_" + ToUpper(suffix)
+	// ToUpper(prefix) + ToUpper(envTag) + ToUpper(suffix) (framework no longer adds underscores)
 	// With prefix "APP_test123_" -> "APP_TEST123_" and suffix "_PROD" -> "_PROD":
-	// APP_TEST123_ + _ + NAME + _ + _PROD = APP_TEST123__NAME__PROD
+	// APP_TEST123_ + NAME + _PROD = APP_TEST123_NAME_PROD
 	envVars := map[string]string{
-		"APP_TEST123__NAME__PROD":    "tenant-app",
-		"APP_TEST123__PORT__PROD":    "9090",
-		"APP_TEST123__ENABLED__PROD": "true",
-		"OTHER_VAR":                  "ignored", // Should not be matched
+		"APP_TEST123_NAME_PROD":    "tenant-app",
+		"APP_TEST123_PORT_PROD":    "9090",
+		"APP_TEST123_ENABLED_PROD": "true",
+		"OTHER_VAR":                "ignored", // Should not be matched
 	}
 
 	// Set environment variables for test
@@ -116,22 +116,22 @@ func TestTenantAffixedEnvFeeder_FieldTracking(t *testing.T) {
 			if fmt.Sprintf("%v", pop.Value) != "tenant-app" {
 				t.Errorf("Expected tracked value 'tenant-app' for Name, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP_TEST123__NAME__PROD" {
-				t.Errorf("Expected SourceKey 'APP_TEST123__NAME__PROD' for Name, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_TEST123_NAME_PROD" {
+				t.Errorf("Expected SourceKey 'APP_TEST123_NAME_PROD' for Name, got %s", pop.SourceKey)
 			}
 		case "Port":
 			if fmt.Sprintf("%v", pop.Value) != "9090" {
 				t.Errorf("Expected tracked value '9090' for Port, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP_TEST123__PORT__PROD" {
-				t.Errorf("Expected SourceKey 'APP_TEST123__PORT__PROD' for Port, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_TEST123_PORT_PROD" {
+				t.Errorf("Expected SourceKey 'APP_TEST123_PORT_PROD' for Port, got %s", pop.SourceKey)
 			}
 		case "Enabled":
 			if fmt.Sprintf("%v", pop.Value) != "true" {
 				t.Errorf("Expected tracked value 'true' for Enabled, got %v", pop.Value)
 			}
-			if pop.SourceKey != "APP_TEST123__ENABLED__PROD" {
-				t.Errorf("Expected SourceKey 'APP_TEST123__ENABLED__PROD' for Enabled, got %s", pop.SourceKey)
+			if pop.SourceKey != "APP_TEST123_ENABLED_PROD" {
+				t.Errorf("Expected SourceKey 'APP_TEST123_ENABLED_PROD' for Enabled, got %s", pop.SourceKey)
 			}
 		}
 	}

--- a/feeders/tenant_affixed_env_nested_config_test.go
+++ b/feeders/tenant_affixed_env_nested_config_test.go
@@ -1,0 +1,469 @@
+package feeders
+
+import (
+	"os"
+	"testing"
+)
+
+// Tests for deeply nested configuration structures to ensure prefix/suffix
+// preservation works at all levels of nesting
+
+// TestTenantAffixedEnvFeeder_NestedConfig_TwoLevels tests a config with
+// one level of nested structs
+func TestTenantAffixedEnvFeeder_NestedConfig_TwoLevels(t *testing.T) {
+	// Set up env vars for nested config
+	// Note: Env tags should include context for clarity (e.g., DATABASE_SSL_ENABLED)
+	os.Setenv("CTL_DATABASE_HOST", "db.example.com")
+	os.Setenv("CTL_DATABASE_PORT", "5432")
+	os.Setenv("CTL_DATABASE_SSL_ENABLED", "true")
+	os.Setenv("CTL_DATABASE_SSL_CERT_PATH", "/etc/ssl/cert.pem")
+	defer func() {
+		os.Unsetenv("CTL_DATABASE_HOST")
+		os.Unsetenv("CTL_DATABASE_PORT")
+		os.Unsetenv("CTL_DATABASE_SSL_ENABLED")
+		os.Unsetenv("CTL_DATABASE_SSL_CERT_PATH")
+	}()
+
+	type SSLConfig struct {
+		Enabled  bool   `env:"DATABASE_SSL_ENABLED"`   // Include parent context
+		CertPath string `env:"DATABASE_SSL_CERT_PATH"` // Include parent context
+	}
+
+	type DatabaseConfig struct {
+		Host string    `env:"DATABASE_HOST"`
+		Port int       `env:"DATABASE_PORT"`
+		SSL  SSLConfig // Nested struct
+	}
+
+	config := &DatabaseConfig{}
+
+	// Create feeder with tenant prefix (include trailing underscore)
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" },
+	)
+
+	// Tenant loader pre-configures prefix
+	feeder.SetPrefixFunc("CTL")
+
+	// Config builder calls FeedKey with section name
+	err := feeder.FeedKey("database", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify top-level fields populated
+	if config.Host != "db.example.com" {
+		t.Errorf("Expected Host 'db.example.com', got: %s", config.Host)
+	}
+	if config.Port != 5432 {
+		t.Errorf("Expected Port 5432, got: %d", config.Port)
+	}
+
+	// Verify nested struct fields populated (critical test!)
+	if !config.SSL.Enabled {
+		t.Errorf("Expected SSL.Enabled true, got: %v", config.SSL.Enabled)
+	}
+	if config.SSL.CertPath != "/etc/ssl/cert.pem" {
+		t.Errorf("Expected SSL.CertPath '/etc/ssl/cert.pem', got: %s", config.SSL.CertPath)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_NestedConfig_ThreeLevels tests a config with
+// two levels of nested structs
+func TestTenantAffixedEnvFeeder_NestedConfig_ThreeLevels(t *testing.T) {
+	// Set up env vars for deeply nested config
+	// Note: env tags should include full context path for clarity
+	os.Setenv("SAMPLEAFF1_API_URL", "https://api.example.com")
+	os.Setenv("SAMPLEAFF1_API_TIMEOUT", "30")
+	os.Setenv("SAMPLEAFF1_API_AUTH_TYPE", "oauth2")
+	os.Setenv("SAMPLEAFF1_API_AUTH_TOKEN", "secret-token")
+	os.Setenv("SAMPLEAFF1_API_AUTH_OAUTH_CLIENT_ID", "client-123")
+	os.Setenv("SAMPLEAFF1_API_AUTH_OAUTH_CLIENT_SECRET", "secret-456")
+	os.Setenv("SAMPLEAFF1_API_AUTH_OAUTH_TOKEN_URL", "https://oauth.example.com/token")
+	defer func() {
+		os.Unsetenv("SAMPLEAFF1_API_URL")
+		os.Unsetenv("SAMPLEAFF1_API_TIMEOUT")
+		os.Unsetenv("SAMPLEAFF1_API_AUTH_TYPE")
+		os.Unsetenv("SAMPLEAFF1_API_AUTH_TOKEN")
+		os.Unsetenv("SAMPLEAFF1_API_AUTH_OAUTH_CLIENT_ID")
+		os.Unsetenv("SAMPLEAFF1_API_AUTH_OAUTH_CLIENT_SECRET")
+		os.Unsetenv("SAMPLEAFF1_API_AUTH_OAUTH_TOKEN_URL")
+	}()
+
+	type OAuthConfig struct {
+		ClientID     string `env:"API_AUTH_OAUTH_CLIENT_ID"`     // Full context path
+		ClientSecret string `env:"API_AUTH_OAUTH_CLIENT_SECRET"` // Full context path
+		TokenURL     string `env:"API_AUTH_OAUTH_TOKEN_URL"`     // Full context path
+	}
+
+	type AuthConfig struct {
+		Type  string      `env:"API_AUTH_TYPE"`  // Include API context
+		Token string      `env:"API_AUTH_TOKEN"` // Include API context
+		OAuth OAuthConfig // Nested struct (level 3)
+	}
+
+	type APIConfig struct {
+		URL     string     `env:"API_URL"`
+		Timeout int        `env:"API_TIMEOUT"`
+		Auth    AuthConfig // Nested struct (level 2)
+	}
+
+	config := &APIConfig{}
+
+	// Create feeder with tenant prefix (include trailing underscore)
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" },
+	)
+
+	// Tenant loader pre-configures prefix
+	feeder.SetPrefixFunc("SAMPLEAFF1")
+
+	// Config builder calls FeedKey with section name
+	err := feeder.FeedKey("api", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify level 1 (top-level) fields
+	if config.URL != "https://api.example.com" {
+		t.Errorf("Expected URL 'https://api.example.com', got: %s", config.URL)
+	}
+	if config.Timeout != 30 {
+		t.Errorf("Expected Timeout 30, got: %d", config.Timeout)
+	}
+
+	// Verify level 2 (nested) fields
+	if config.Auth.Type != "oauth2" {
+		t.Errorf("Expected Auth.Type 'oauth2', got: %s", config.Auth.Type)
+	}
+	if config.Auth.Token != "secret-token" {
+		t.Errorf("Expected Auth.Token 'secret-token', got: %s", config.Auth.Token)
+	}
+
+	// Verify level 3 (deeply nested) fields - CRITICAL!
+	if config.Auth.OAuth.ClientID != "client-123" {
+		t.Errorf("Expected Auth.OAuth.ClientID 'client-123', got: %s", config.Auth.OAuth.ClientID)
+	}
+	if config.Auth.OAuth.ClientSecret != "secret-456" {
+		t.Errorf("Expected Auth.OAuth.ClientSecret 'secret-456', got: %s", config.Auth.OAuth.ClientSecret)
+	}
+	if config.Auth.OAuth.TokenURL != "https://oauth.example.com/token" {
+		t.Errorf("Expected Auth.OAuth.TokenURL 'https://oauth.example.com/token', got: %s", config.Auth.OAuth.TokenURL)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_NestedConfig_WithPointers tests nested structs
+// using pointer fields (common pattern for optional nested configs)
+func TestTenantAffixedEnvFeeder_NestedConfig_WithPointers(t *testing.T) {
+	os.Setenv("CTL_CACHE_ENABLED", "true")
+	os.Setenv("CTL_CACHE_TTL", "3600")
+	os.Setenv("CTL_CACHE_REDIS_HOST", "redis.example.com")
+	os.Setenv("CTL_CACHE_REDIS_PORT", "6379")
+	os.Setenv("CTL_CACHE_REDIS_PASSWORD", "redis-secret")
+	defer func() {
+		os.Unsetenv("CTL_CACHE_ENABLED")
+		os.Unsetenv("CTL_CACHE_TTL")
+		os.Unsetenv("CTL_CACHE_REDIS_HOST")
+		os.Unsetenv("CTL_CACHE_REDIS_PORT")
+		os.Unsetenv("CTL_CACHE_REDIS_PASSWORD")
+	}()
+
+	type RedisConfig struct {
+		Host     string `env:"CACHE_REDIS_HOST"`     // Include cache context
+		Port     int    `env:"CACHE_REDIS_PORT"`     // Include cache context
+		Password string `env:"CACHE_REDIS_PASSWORD"` // Include cache context
+	}
+
+	type CacheConfig struct {
+		Enabled bool         `env:"CACHE_ENABLED"`
+		TTL     int          `env:"CACHE_TTL"`
+		Redis   *RedisConfig // Pointer to nested struct
+	}
+
+	// Initialize with pointer
+	config := &CacheConfig{
+		Redis: &RedisConfig{}, // Pre-initialize pointer
+	}
+
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" },
+	)
+
+	feeder.SetPrefixFunc("CTL")
+
+	err := feeder.FeedKey("cache", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify top-level fields
+	if !config.Enabled {
+		t.Errorf("Expected Enabled true, got: %v", config.Enabled)
+	}
+	if config.TTL != 3600 {
+		t.Errorf("Expected TTL 3600, got: %d", config.TTL)
+	}
+
+	// Verify nested pointer struct fields
+	if config.Redis == nil {
+		t.Fatal("Expected Redis to be non-nil")
+	}
+	if config.Redis.Host != "redis.example.com" {
+		t.Errorf("Expected Redis.Host 'redis.example.com', got: %s", config.Redis.Host)
+	}
+	if config.Redis.Port != 6379 {
+		t.Errorf("Expected Redis.Port 6379, got: %d", config.Redis.Port)
+	}
+	if config.Redis.Password != "redis-secret" {
+		t.Errorf("Expected Redis.Password 'redis-secret', got: %s", config.Redis.Password)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_NestedConfig_MultipleSections tests that prefix
+// is preserved across multiple sections with nested configs
+func TestTenantAffixedEnvFeeder_NestedConfig_MultipleSections(t *testing.T) {
+	// Section 1: AWS config (nested)
+	os.Setenv("CTL_AWS_REGION", "us-east-1")
+	os.Setenv("CTL_AWS_S3_BUCKET", "ctl-uploads")
+	os.Setenv("CTL_AWS_S3_PREFIX", "prod/")
+
+	// Section 2: Database config (nested)
+	os.Setenv("CTL_DB_HOST", "db.example.com")
+	os.Setenv("CTL_DB_POOL_MIN_CONNS", "5")
+	os.Setenv("CTL_DB_POOL_MAX_CONNS", "20")
+
+	defer func() {
+		os.Unsetenv("CTL_AWS_REGION")
+		os.Unsetenv("CTL_AWS_S3_BUCKET")
+		os.Unsetenv("CTL_AWS_S3_PREFIX")
+		os.Unsetenv("CTL_DB_HOST")
+		os.Unsetenv("CTL_DB_POOL_MIN_CONNS")
+		os.Unsetenv("CTL_DB_POOL_MAX_CONNS")
+	}()
+
+	type S3Config struct {
+		Bucket string `env:"AWS_S3_BUCKET"` // Include AWS context
+		Prefix string `env:"AWS_S3_PREFIX"` // Include AWS context
+	}
+
+	type AWSConfig struct {
+		Region string   `env:"AWS_REGION"`
+		S3     S3Config // Nested
+	}
+
+	type PoolConfig struct {
+		MinConns int `env:"DB_POOL_MIN_CONNS"` // Include DB context
+		MaxConns int `env:"DB_POOL_MAX_CONNS"` // Include DB context
+	}
+
+	type DBConfig struct {
+		Host string     `env:"DB_HOST"`
+		Pool PoolConfig // Nested
+	}
+
+	awsConfig := &AWSConfig{}
+	dbConfig := &DBConfig{}
+
+	// Create feeder once, use for both sections
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" },
+	)
+
+	// Tenant loader pre-configures prefix once
+	feeder.SetPrefixFunc("CTL")
+
+	// Simulate config builder processing multiple sections
+	// Section 1: aws
+	err := feeder.FeedKey("aws", awsConfig)
+	if err != nil {
+		t.Errorf("FeedKey for aws failed: %v", err)
+	}
+
+	// Verify prefix is still CTL_ after first section (includes trailing underscore from prefix function)
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix 'CTL_' after first section, got: %s", feeder.Prefix)
+	}
+
+	// Section 2: database
+	err = feeder.FeedKey("database", dbConfig)
+	if err != nil {
+		t.Errorf("FeedKey for database failed: %v", err)
+	}
+
+	// Verify prefix is STILL CTL_ after second section (not overwritten to "database_")
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix 'CTL_' after second section, got: %s", feeder.Prefix)
+	}
+
+	// Verify AWS config (section 1) with nested struct
+	if awsConfig.Region != "us-east-1" {
+		t.Errorf("Expected AWS Region 'us-east-1', got: %s", awsConfig.Region)
+	}
+	if awsConfig.S3.Bucket != "ctl-uploads" {
+		t.Errorf("Expected AWS S3 Bucket 'ctl-uploads', got: %s", awsConfig.S3.Bucket)
+	}
+	if awsConfig.S3.Prefix != "prod/" {
+		t.Errorf("Expected AWS S3 Prefix 'prod/', got: %s", awsConfig.S3.Prefix)
+	}
+
+	// Verify DB config (section 2) with nested struct
+	if dbConfig.Host != "db.example.com" {
+		t.Errorf("Expected DB Host 'db.example.com', got: %s", dbConfig.Host)
+	}
+	if dbConfig.Pool.MinConns != 5 {
+		t.Errorf("Expected DB Pool MinConns 5, got: %d", dbConfig.Pool.MinConns)
+	}
+	if dbConfig.Pool.MaxConns != 20 {
+		t.Errorf("Expected DB Pool MaxConns 20, got: %d", dbConfig.Pool.MaxConns)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_NestedConfig_WithSuffix tests nested configs
+// with both tenant prefix and environment suffix
+func TestTenantAffixedEnvFeeder_NestedConfig_WithSuffix(t *testing.T) {
+	os.Setenv("CTL_SERVICE_URL_PROD", "https://ctl-prod.example.com")
+	os.Setenv("CTL_SERVICE_TIMEOUT_PROD", "60")
+	os.Setenv("CTL_SERVICE_RETRY_MAX_ATTEMPTS_PROD", "3")
+	os.Setenv("CTL_SERVICE_RETRY_BACKOFF_MS_PROD", "1000")
+	defer func() {
+		os.Unsetenv("CTL_SERVICE_URL_PROD")
+		os.Unsetenv("CTL_SERVICE_TIMEOUT_PROD")
+		os.Unsetenv("CTL_SERVICE_RETRY_MAX_ATTEMPTS_PROD")
+		os.Unsetenv("CTL_SERVICE_RETRY_BACKOFF_MS_PROD")
+	}()
+
+	type RetryConfig struct {
+		MaxAttempts int `env:"SERVICE_RETRY_MAX_ATTEMPTS"` // Include service context
+		BackoffMs   int `env:"SERVICE_RETRY_BACKOFF_MS"`   // Include service context
+	}
+
+	type ServiceConfig struct {
+		URL     string      `env:"SERVICE_URL"`
+		Timeout int         `env:"SERVICE_TIMEOUT"`
+		Retry   RetryConfig // Nested
+	}
+
+	config := &ServiceConfig{}
+
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Configure both prefix and suffix
+	feeder.SetPrefixFunc("CTL")
+	feeder.SetSuffixFunc("PROD")
+
+	// Config builder calls FeedKey with section name
+	err := feeder.FeedKey("service", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify both prefix and suffix preserved (with separators included)
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Errorf("Expected suffix '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Verify top-level fields with prefix and suffix
+	if config.URL != "https://ctl-prod.example.com" {
+		t.Errorf("Expected URL 'https://ctl-prod.example.com', got: %s", config.URL)
+	}
+	if config.Timeout != 60 {
+		t.Errorf("Expected Timeout 60, got: %d", config.Timeout)
+	}
+
+	// Verify nested struct fields with prefix and suffix
+	if config.Retry.MaxAttempts != 3 {
+		t.Errorf("Expected Retry.MaxAttempts 3, got: %d", config.Retry.MaxAttempts)
+	}
+	if config.Retry.BackoffMs != 1000 {
+		t.Errorf("Expected Retry.BackoffMs 1000, got: %d", config.Retry.BackoffMs)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_NestedConfig_FourLevels tests extremely deep nesting
+func TestTenantAffixedEnvFeeder_NestedConfig_FourLevels(t *testing.T) {
+	os.Setenv("TENANT1_APP_NAME", "myapp")
+	os.Setenv("TENANT1_APP_SERVER_HOST", "localhost")
+	os.Setenv("TENANT1_APP_SERVER_TLS_ENABLED", "true")
+	os.Setenv("TENANT1_APP_SERVER_TLS_CERTS_CA_PATH", "/etc/ssl/ca.pem")
+	os.Setenv("TENANT1_APP_SERVER_TLS_CERTS_CERT_PATH", "/etc/ssl/cert.pem")
+	os.Setenv("TENANT1_APP_SERVER_TLS_CERTS_KEY_PATH", "/etc/ssl/key.pem")
+	defer func() {
+		os.Unsetenv("TENANT1_APP_NAME")
+		os.Unsetenv("TENANT1_APP_SERVER_HOST")
+		os.Unsetenv("TENANT1_APP_SERVER_TLS_ENABLED")
+		os.Unsetenv("TENANT1_APP_SERVER_TLS_CERTS_CA_PATH")
+		os.Unsetenv("TENANT1_APP_SERVER_TLS_CERTS_CERT_PATH")
+		os.Unsetenv("TENANT1_APP_SERVER_TLS_CERTS_KEY_PATH")
+	}()
+
+	type CertsConfig struct {
+		CAPath   string `env:"APP_SERVER_TLS_CERTS_CA_PATH"`   // Full context path
+		CertPath string `env:"APP_SERVER_TLS_CERTS_CERT_PATH"` // Full context path
+		KeyPath  string `env:"APP_SERVER_TLS_CERTS_KEY_PATH"`  // Full context path
+	}
+
+	type TLSConfig struct {
+		Enabled bool        `env:"APP_SERVER_TLS_ENABLED"` // Full context path
+		Certs   CertsConfig // Level 4
+	}
+
+	type ServerConfig struct {
+		Host string    `env:"APP_SERVER_HOST"` // Include app context
+		TLS  TLSConfig // Level 3
+	}
+
+	type AppConfig struct {
+		Name   string       `env:"APP_NAME"`
+		Server ServerConfig // Level 2
+	}
+
+	config := &AppConfig{}
+
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" },
+	)
+
+	feeder.SetPrefixFunc("TENANT1")
+
+	err := feeder.FeedKey("app", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify level 1
+	if config.Name != "myapp" {
+		t.Errorf("Expected Name 'myapp', got: %s", config.Name)
+	}
+
+	// Verify level 2
+	if config.Server.Host != "localhost" {
+		t.Errorf("Expected Server.Host 'localhost', got: %s", config.Server.Host)
+	}
+
+	// Verify level 3
+	if !config.Server.TLS.Enabled {
+		t.Errorf("Expected Server.TLS.Enabled true, got: %v", config.Server.TLS.Enabled)
+	}
+
+	// Verify level 4 (deepest nesting) - CRITICAL!
+	if config.Server.TLS.Certs.CAPath != "/etc/ssl/ca.pem" {
+		t.Errorf("Expected Server.TLS.Certs.CAPath '/etc/ssl/ca.pem', got: %s", config.Server.TLS.Certs.CAPath)
+	}
+	if config.Server.TLS.Certs.CertPath != "/etc/ssl/cert.pem" {
+		t.Errorf("Expected Server.TLS.Certs.CertPath '/etc/ssl/cert.pem', got: %s", config.Server.TLS.Certs.CertPath)
+	}
+	if config.Server.TLS.Certs.KeyPath != "/etc/ssl/key.pem" {
+		t.Errorf("Expected Server.TLS.Certs.KeyPath '/etc/ssl/key.pem', got: %s", config.Server.TLS.Certs.KeyPath)
+	}
+}

--- a/feeders/tenant_affixed_env_prefix_suffix_preservation_test.go
+++ b/feeders/tenant_affixed_env_prefix_suffix_preservation_test.go
@@ -1,0 +1,471 @@
+package feeders
+
+import (
+	"os"
+	"testing"
+)
+
+// TestTenantAffixedEnvFeeder_FeedWithoutPrefixSuffix tests the NEW behavior where
+// Feed() returns nil instead of error when prefix/suffix are not configured
+func TestTenantAffixedEnvFeeder_FeedWithoutPrefixSuffix(t *testing.T) {
+	type TestConfig struct {
+		Name string `env:"NAME"`
+		Port int    `env:"PORT"`
+	}
+
+	config := &TestConfig{}
+
+	// Create feeder without pre-configuring prefix/suffix
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return "PREFIX_" + tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Feed() should now return nil (NEW behavior - not an error)
+	err := feeder.Feed(config)
+	if err != nil {
+		t.Errorf("Expected Feed() to return nil when prefix/suffix not set, got error: %v", err)
+	}
+
+	// Verify prefix and suffix are still empty (Feed did nothing)
+	if feeder.Prefix != "" {
+		t.Errorf("Expected Prefix to remain empty, got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "" {
+		t.Errorf("Expected Suffix to remain empty, got: %s", feeder.Suffix)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_FeedKeyPreservesPreConfiguredPrefix tests that
+// FeedKey() preserves prefix when it's already set (NEW behavior)
+func TestTenantAffixedEnvFeeder_FeedKeyPreservesPreConfiguredPrefix(t *testing.T) {
+	// Set up environment variable with pre-configured prefix
+	// Format: PREFIX_CTL_ + NAME = PREFIX_CTL_NAME (framework no longer adds underscores)
+	os.Setenv("PREFIX_CTL_NAME", "crisis-text-line")
+	defer os.Unsetenv("PREFIX_CTL_NAME")
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+	}
+
+	config := &TestConfig{}
+
+	// Create feeder
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return "PREFIX_" + tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Pre-configure prefix to "PREFIX_CTL_" (simulating tenant loader behavior)
+	feeder.SetPrefixFunc("CTL")
+	if feeder.Prefix != "PREFIX_CTL_" {
+		t.Fatalf("Expected prefix 'PREFIX_CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Now call FeedKey with a different key (section name)
+	// FeedKey should PRESERVE the prefix, not overwrite it
+	err := feeder.FeedKey("notifications", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix was preserved (NOT overwritten with "PREFIX_notifications_")
+	if feeder.Prefix != "PREFIX_CTL_" {
+		t.Errorf("Expected prefix to be preserved as 'PREFIX_CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Verify config was populated using the preserved prefix
+	if config.Name != "crisis-text-line" {
+		t.Errorf("Expected Name to be 'crisis-text-line', got: %s", config.Name)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_FeedKeyPreservesPreConfiguredSuffix tests that
+// FeedKey() preserves suffix when it's already set (NEW behavior)
+// When only suffix is set (prefix empty), FeedKey preserves BOTH - doesn't set prefix from key
+func TestTenantAffixedEnvFeeder_FeedKeyPreservesPreConfiguredSuffix(t *testing.T) {
+	// Set up environment variable with only suffix (no prefix)
+	// Format: NAME + _PROD = NAME_PROD (framework no longer adds underscores)
+	os.Setenv("NAME_PROD", "production-app")
+	defer os.Unsetenv("NAME_PROD")
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+	}
+
+	config := &TestConfig{}
+
+	// Create feeder
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Pre-configure suffix to "_PROD" (simulating tenant loader behavior)
+	feeder.SetSuffixFunc("PROD")
+	if feeder.Suffix != "_PROD" {
+		t.Fatalf("Expected suffix '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Now call FeedKey with a different key (section name)
+	// FeedKey should PRESERVE both - prefix stays empty, suffix preserved
+	err := feeder.FeedKey("database", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix stays empty (NOT set from key)
+	if feeder.Prefix != "" {
+		t.Errorf("Expected prefix to remain empty, got: %s", feeder.Prefix)
+	}
+
+	// Verify suffix was preserved (NOT overwritten with "_database")
+	if feeder.Suffix != "_PROD" {
+		t.Errorf("Expected suffix to be preserved as '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Verify config was populated using the preserved suffix
+	if config.Name != "production-app" {
+		t.Errorf("Expected Name 'production-app', got: %s", config.Name)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_FeedKeyPreservesBothPrefixAndSuffix tests that
+// FeedKey() preserves both prefix and suffix when both are set (NEW behavior)
+func TestTenantAffixedEnvFeeder_FeedKeyPreservesBothPrefixAndSuffix(t *testing.T) {
+	// Set up environment variable with both prefix and suffix
+	os.Setenv("CTL_NAME_PROD", "ctl-production")
+	defer os.Unsetenv("CTL_NAME_PROD")
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+	}
+
+	config := &TestConfig{}
+
+	// Create feeder
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Pre-configure both prefix and suffix (simulating tenant loader behavior)
+	feeder.SetPrefixFunc("CTL")
+	feeder.SetSuffixFunc("PROD")
+
+	if feeder.Prefix != "CTL_" {
+		t.Fatalf("Expected prefix 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Fatalf("Expected suffix '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Now call FeedKey with a section name
+	// FeedKey should PRESERVE both prefix and suffix
+	err := feeder.FeedKey("aws", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify both were preserved
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix to be preserved as 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Errorf("Expected suffix to be preserved as '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Verify config was populated correctly
+	if config.Name != "ctl-production" {
+		t.Errorf("Expected Name to be 'ctl-production', got: %s", config.Name)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_FeedKeySetsFromKeyWhenNotPreConfigured tests that
+// FeedKey() still sets prefix/suffix from key when they're not pre-configured (backward compatibility)
+func TestTenantAffixedEnvFeeder_FeedKeySetsFromKeyWhenNotPreConfigured(t *testing.T) {
+	// Set up environment variable with tenant-specific prefix and suffix
+	// Prefix func returns: tenantId + "_" = "tenant123_"
+	// Suffix func returns: "_" + env = "_tenant123"
+	// Format: TENANT123_ + NAME + _TENANT123 = TENANT123_NAME_TENANT123 (ToUpper applied, framework no longer adds underscores)
+	os.Setenv("TENANT123_NAME_TENANT123", "tenant-app")
+	defer os.Unsetenv("TENANT123_NAME_TENANT123")
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+	}
+
+	config := &TestConfig{}
+
+	// Create feeder WITHOUT pre-configuring prefix/suffix
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Call FeedKey with tenant ID - should set prefix AND suffix from the key parameter
+	err := feeder.FeedKey("tenant123", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix was set from the key parameter
+	if feeder.Prefix != "tenant123_" {
+		t.Errorf("Expected prefix 'tenant123_', got: %s", feeder.Prefix)
+	}
+
+	// Verify suffix was also set from the key parameter
+	if feeder.Suffix != "_tenant123" {
+		t.Errorf("Expected suffix '_tenant123', got: %s", feeder.Suffix)
+	}
+
+	// Verify config was populated
+	if config.Name != "tenant-app" {
+		t.Errorf("Expected Name to be 'tenant-app', got: %s", config.Name)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_SequentialFeedKeyCallsPreserveFirst tests that
+// when FeedKey is called multiple times, the first prefix/suffix are preserved
+func TestTenantAffixedEnvFeeder_SequentialFeedKeyCallsPreserveFirst(t *testing.T) {
+	// Set up environment variables for first tenant
+	// Prefix: tenant1_ , Suffix: _tenant1
+	// Format: TENANT1_ + NAME + _TENANT1 = TENANT1_NAME_TENANT1 (framework no longer adds underscores)
+	os.Setenv("TENANT1_NAME_TENANT1", "tenant-one")
+	os.Setenv("TENANT1_PORT_TENANT1", "8080")
+	defer func() {
+		os.Unsetenv("TENANT1_NAME_TENANT1")
+		os.Unsetenv("TENANT1_PORT_TENANT1")
+	}()
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+		Port int    `env:"PORT"`
+	}
+
+	config1 := &TestConfig{}
+	config2 := &TestConfig{}
+
+	// Create feeder
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// First FeedKey call - sets prefix to "tenant1_" and suffix to "_tenant1"
+	err := feeder.FeedKey("tenant1", config1)
+	if err != nil {
+		t.Errorf("First FeedKey failed: %v", err)
+	}
+
+	if feeder.Prefix != "tenant1_" {
+		t.Fatalf("Expected first prefix 'tenant1_', got: %s", feeder.Prefix)
+	}
+
+	if feeder.Suffix != "_tenant1" {
+		t.Fatalf("Expected first suffix '_tenant1', got: %s", feeder.Suffix)
+	}
+
+	if config1.Name != "tenant-one" {
+		t.Errorf("Expected first config Name 'tenant-one', got: %s", config1.Name)
+	}
+
+	// Second FeedKey call with different key - should PRESERVE "tenant1_" prefix and suffix
+	err = feeder.FeedKey("tenant2", config2)
+	if err != nil {
+		t.Errorf("Second FeedKey failed: %v", err)
+	}
+
+	// Verify prefix was preserved (not overwritten to "tenant2_")
+	if feeder.Prefix != "tenant1_" {
+		t.Errorf("Expected prefix to remain 'tenant1_' after second call, got: %s", feeder.Prefix)
+	}
+
+	// Verify suffix was preserved (not overwritten to "_tenant2")
+	if feeder.Suffix != "_tenant1" {
+		t.Errorf("Expected suffix to remain '_tenant1' after second call, got: %s", feeder.Suffix)
+	}
+
+	// Second config should also use first tenant's env vars
+	if config2.Name != "tenant-one" {
+		t.Errorf("Expected second config to use preserved prefix, got Name: %s", config2.Name)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_TenantLoaderWorkflow tests the complete workflow
+// where tenant loader pre-configures prefix, then config builder calls FeedKey with section names
+func TestTenantAffixedEnvFeeder_TenantLoaderWorkflow(t *testing.T) {
+	// Set up environment variables for CTL tenant with AWS section
+	// Format: CTL_ + AWS_REGION = CTL_AWS_REGION (framework no longer adds underscores)
+	os.Setenv("CTL_AWS_REGION", "us-east-1")
+	os.Setenv("CTL_AWS_BUCKET", "ctl-uploads")
+	os.Setenv("CTL_DATABASE_HOST", "ctl-db.example.com")
+	os.Setenv("CTL_DATABASE_PORT", "5432")
+	defer func() {
+		os.Unsetenv("CTL_AWS_REGION")
+		os.Unsetenv("CTL_AWS_BUCKET")
+		os.Unsetenv("CTL_DATABASE_HOST")
+		os.Unsetenv("CTL_DATABASE_PORT")
+	}()
+
+	type AWSConfig struct {
+		Region string `env:"AWS_REGION"`
+		Bucket string `env:"AWS_BUCKET"`
+	}
+
+	type DatabaseConfig struct {
+		Host string `env:"DATABASE_HOST"`
+		Port int    `env:"DATABASE_PORT"`
+	}
+
+	awsConfig := &AWSConfig{}
+	dbConfig := &DatabaseConfig{}
+
+	// Create feeder (as tenant loader would)
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Step 1: Tenant loader pre-configures prefix for tenant "CTL"
+	feeder.SetPrefixFunc("CTL")
+	if feeder.Prefix != "CTL_" {
+		t.Fatalf("Expected prefix 'CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Step 2: Config builder calls FeedKey with section name "aws"
+	// This should PRESERVE the "CTL_" prefix, not overwrite it with "aws_"
+	err := feeder.FeedKey("aws", awsConfig)
+	if err != nil {
+		t.Errorf("FeedKey for aws section failed: %v", err)
+	}
+
+	// Verify prefix was preserved
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix preserved as 'CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Verify AWS config was loaded correctly using CTL_ prefix
+	if awsConfig.Region != "us-east-1" {
+		t.Errorf("Expected AWS Region 'us-east-1', got: %s", awsConfig.Region)
+	}
+	if awsConfig.Bucket != "ctl-uploads" {
+		t.Errorf("Expected AWS Bucket 'ctl-uploads', got: %s", awsConfig.Bucket)
+	}
+
+	// Step 3: Config builder calls FeedKey again with section name "database"
+	// Prefix should STILL be preserved
+	err = feeder.FeedKey("database", dbConfig)
+	if err != nil {
+		t.Errorf("FeedKey for database section failed: %v", err)
+	}
+
+	// Verify prefix still preserved
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix still preserved as 'CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Verify database config was loaded correctly using CTL_ prefix
+	if dbConfig.Host != "ctl-db.example.com" {
+		t.Errorf("Expected Database Host 'ctl-db.example.com', got: %s", dbConfig.Host)
+	}
+	if dbConfig.Port != 5432 {
+		t.Errorf("Expected Database Port 5432, got: %d", dbConfig.Port)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_OnlyPrefixPreConfigured tests preservation when only prefix is set
+// The behavior: if EITHER prefix or suffix is set, FeedKey preserves BOTH (no setting from key)
+func TestTenantAffixedEnvFeeder_OnlyPrefixPreConfigured(t *testing.T) {
+	// Env var format: CTL_ + NAME = CTL_NAME (no suffix, framework no longer adds underscores)
+	os.Setenv("CTL_NAME", "ctl-app")
+	defer os.Unsetenv("CTL_NAME")
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+	}
+
+	config := &TestConfig{}
+
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Only set prefix, not suffix
+	feeder.SetPrefixFunc("CTL")
+
+	// Verify only prefix is set
+	if feeder.Prefix != "CTL_" {
+		t.Fatalf("Expected prefix 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "" {
+		t.Fatalf("Expected suffix to be empty, got: %s", feeder.Suffix)
+	}
+
+	// FeedKey should preserve BOTH - prefix stays, suffix stays empty (NOT set from key)
+	err := feeder.FeedKey("DEV", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix preserved and suffix STILL empty (not set to "_DEV")
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix preserved as 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "" {
+		t.Errorf("Expected suffix to remain empty, got: %s", feeder.Suffix)
+	}
+
+	if config.Name != "ctl-app" {
+		t.Errorf("Expected Name 'ctl-app', got: %s", config.Name)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_OnlySuffixPreConfigured tests preservation when only suffix is set
+// The behavior: if EITHER prefix or suffix is set, FeedKey preserves BOTH (no setting from key)
+func TestTenantAffixedEnvFeeder_OnlySuffixPreConfigured(t *testing.T) {
+	// Env var format: NAME + _PROD = NAME_PROD (framework no longer adds underscores)
+	os.Setenv("NAME_PROD", "prod-app")
+	defer os.Unsetenv("NAME_PROD")
+
+	type TestConfig struct {
+		Name string `env:"NAME"`
+	}
+
+	config := &TestConfig{}
+
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Only set suffix, not prefix
+	feeder.SetSuffixFunc("PROD")
+
+	// Verify only suffix is set
+	if feeder.Prefix != "" {
+		t.Fatalf("Expected prefix to be empty, got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Fatalf("Expected suffix '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// FeedKey should preserve BOTH - prefix stays empty, suffix stays (NOT set from key)
+	err := feeder.FeedKey("tenant1", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix STILL empty (not set to "tenant1_") and suffix preserved
+	if feeder.Prefix != "" {
+		t.Errorf("Expected prefix to remain empty, got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Errorf("Expected suffix preserved as '_PROD', got: %s", feeder.Suffix)
+	}
+
+	if config.Name != "prod-app" {
+		t.Errorf("Expected Name 'prod-app', got: %s", config.Name)
+	}
+}

--- a/feeders/tenant_affixed_env_real_world_test.go
+++ b/feeders/tenant_affixed_env_real_world_test.go
@@ -1,0 +1,307 @@
+package feeders
+
+import (
+	"os"
+	"testing"
+)
+
+// Real-world usage tests where prefix/suffix don't include extra underscores
+// The code itself adds _ between prefix/envtag and envtag/suffix
+
+// TestTenantAffixedEnvFeeder_RealWorld_TenantPrefix tests the intended usage
+// where prefix is just the tenant name (e.g., "CTL") without trailing underscore
+func TestTenantAffixedEnvFeeder_RealWorld_TenantPrefix(t *testing.T) {
+	// Real-world env var: CTL_AWS_REGION (not CTL__AWS_REGION)
+	// Prefix: "CTL" (code adds _)
+	// EnvTag: "AWS_REGION"
+	// Result: CTL + _ + AWS_REGION = CTL_AWS_REGION
+	os.Setenv("CTL_AWS_REGION", "us-east-1")
+	os.Setenv("CTL_AWS_BUCKET", "ctl-uploads")
+	defer func() {
+		os.Unsetenv("CTL_AWS_REGION")
+		os.Unsetenv("CTL_AWS_BUCKET")
+	}()
+
+	type AWSConfig struct {
+		Region string `env:"AWS_REGION"`
+		Bucket string `env:"AWS_BUCKET"`
+	}
+
+	config := &AWSConfig{}
+
+	// Create feeder with prefix/suffix functions that include underscores
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" }, // Include trailing underscore
+		func(env string) string { return "" },                  // No suffix in this example
+	)
+
+	// Tenant loader pre-configures prefix
+	feeder.SetPrefixFunc("CTL")
+
+	// Verify prefix is set with underscore
+	if feeder.Prefix != "CTL_" {
+		t.Fatalf("Expected prefix 'CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Config builder calls FeedKey with section name - should PRESERVE "CTL" prefix
+	err := feeder.FeedKey("aws", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix was preserved
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix preserved as 'CTL_', got: %s", feeder.Prefix)
+	}
+
+	// Verify config was loaded
+	if config.Region != "us-east-1" {
+		t.Errorf("Expected Region 'us-east-1', got: %s", config.Region)
+	}
+	if config.Bucket != "ctl-uploads" {
+		t.Errorf("Expected Bucket 'ctl-uploads', got: %s", config.Bucket)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_RealWorld_TenantPrefixAndEnvSuffix tests usage
+// with both tenant prefix and environment suffix
+func TestTenantAffixedEnvFeeder_RealWorld_TenantPrefixAndEnvSuffix(t *testing.T) {
+	// Real-world env var: CTL_DATABASE_HOST_PROD
+	// Prefix: "CTL"
+	// EnvTag: "DATABASE_HOST"
+	// Suffix: "PROD"
+	// Result: CTL + _ + DATABASE_HOST + _ + PROD = CTL_DATABASE_HOST_PROD
+	os.Setenv("CTL_DATABASE_HOST_PROD", "ctl-prod-db.example.com")
+	os.Setenv("CTL_DATABASE_PORT_PROD", "5432")
+	defer func() {
+		os.Unsetenv("CTL_DATABASE_HOST_PROD")
+		os.Unsetenv("CTL_DATABASE_PORT_PROD")
+	}()
+
+	type DatabaseConfig struct {
+		Host string `env:"DATABASE_HOST"`
+		Port int    `env:"DATABASE_PORT"`
+	}
+
+	config := &DatabaseConfig{}
+
+	// Create feeder with functions that include underscores
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" }, // Include trailing underscore
+		func(env string) string { return "_" + env },           // Include leading underscore
+	)
+
+	// Tenant loader pre-configures BOTH prefix and suffix
+	feeder.SetPrefixFunc("CTL")
+	feeder.SetSuffixFunc("PROD")
+
+	// Verify both are set with underscores
+	if feeder.Prefix != "CTL_" {
+		t.Fatalf("Expected prefix 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Fatalf("Expected suffix '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Config builder calls FeedKey - should preserve both
+	err := feeder.FeedKey("database", config)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify both preserved
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("Expected prefix preserved as 'CTL_', got: %s", feeder.Prefix)
+	}
+	if feeder.Suffix != "_PROD" {
+		t.Errorf("Expected suffix preserved as '_PROD', got: %s", feeder.Suffix)
+	}
+
+	// Verify config was loaded
+	if config.Host != "ctl-prod-db.example.com" {
+		t.Errorf("Expected Host 'ctl-prod-db.example.com', got: %s", config.Host)
+	}
+	if config.Port != 5432 {
+		t.Errorf("Expected Port 5432, got: %d", config.Port)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_RealWorld_MultiTenantWorkflow simulates the
+// complete multi-tenant workflow with realistic env var names
+func TestTenantAffixedEnvFeeder_RealWorld_MultiTenantWorkflow(t *testing.T) {
+	// Simulate multiple tenants with realistic env vars
+	// CTL tenant:
+	os.Setenv("CTL_API_KEY_PROD", "ctl-prod-key-123")
+	os.Setenv("CTL_API_URL_PROD", "https://ctl-api.example.com")
+	// SAMPLEAFF1 tenant:
+	os.Setenv("SAMPLEAFF1_API_KEY_PROD", "aff1-prod-key-456")
+	os.Setenv("SAMPLEAFF1_API_URL_PROD", "https://aff1-api.example.com")
+
+	defer func() {
+		os.Unsetenv("CTL_API_KEY_PROD")
+		os.Unsetenv("CTL_API_URL_PROD")
+		os.Unsetenv("SAMPLEAFF1_API_KEY_PROD")
+		os.Unsetenv("SAMPLEAFF1_API_URL_PROD")
+	}()
+
+	type APIConfig struct {
+		Key string `env:"API_KEY"`
+		URL string `env:"API_URL"`
+	}
+
+	// Test CTL tenant
+	ctlConfig := &APIConfig{}
+	ctlFeeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Tenant loader configures for CTL tenant in PROD environment
+	ctlFeeder.SetPrefixFunc("CTL")
+	ctlFeeder.SetSuffixFunc("PROD")
+
+	// Load config (FeedKey called with section name)
+	err := ctlFeeder.FeedKey("api", ctlConfig)
+	if err != nil {
+		t.Errorf("CTL FeedKey failed: %v", err)
+	}
+
+	// Verify CTL config
+	if ctlConfig.Key != "ctl-prod-key-123" {
+		t.Errorf("Expected CTL Key 'ctl-prod-key-123', got: %s", ctlConfig.Key)
+	}
+	if ctlConfig.URL != "https://ctl-api.example.com" {
+		t.Errorf("Expected CTL URL 'https://ctl-api.example.com', got: %s", ctlConfig.URL)
+	}
+
+	// Test SAMPLEAFF1 tenant
+	aff1Config := &APIConfig{}
+	aff1Feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "_" + env },
+	)
+
+	// Tenant loader configures for SAMPLEAFF1 tenant in PROD environment
+	aff1Feeder.SetPrefixFunc("SAMPLEAFF1")
+	aff1Feeder.SetSuffixFunc("PROD")
+
+	// Load config (FeedKey called with section name)
+	err = aff1Feeder.FeedKey("api", aff1Config)
+	if err != nil {
+		t.Errorf("SAMPLEAFF1 FeedKey failed: %v", err)
+	}
+
+	// Verify SAMPLEAFF1 config
+	if aff1Config.Key != "aff1-prod-key-456" {
+		t.Errorf("Expected SAMPLEAFF1 Key 'aff1-prod-key-456', got: %s", aff1Config.Key)
+	}
+	if aff1Config.URL != "https://aff1-api.example.com" {
+		t.Errorf("Expected SAMPLEAFF1 URL 'https://aff1-api.example.com', got: %s", aff1Config.URL)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_RealWorld_FeedKeyPreservation tests the critical
+// NEW behavior: FeedKey preserves pre-configured prefix/suffix
+func TestTenantAffixedEnvFeeder_RealWorld_FeedKeyPreservation(t *testing.T) {
+	// Real-world scenario from PR description:
+	// Tenant loader pre-configures prefix (e.g., "CTL")
+	// Config builder calls FeedKey() with section name (e.g., "aws")
+	// OLD behavior would overwrite prefix to "aws"
+	// NEW behavior preserves prefix as "CTL"
+
+	// Env vars for CTL tenant
+	os.Setenv("CTL_IMAGE_UPLOAD_BUCKET", "ctl-images")
+	os.Setenv("CTL_VIDEO_UPLOAD_BUCKET", "ctl-videos")
+	defer func() {
+		os.Unsetenv("CTL_IMAGE_UPLOAD_BUCKET")
+		os.Unsetenv("CTL_VIDEO_UPLOAD_BUCKET")
+	}()
+
+	type UploadConfig struct {
+		ImageBucket string `env:"IMAGE_UPLOAD_BUCKET"`
+		VideoBucket string `env:"VIDEO_UPLOAD_BUCKET"`
+	}
+
+	uploadConfig := &UploadConfig{}
+
+	// Create feeder (realistic usage)
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" }, // No suffix in this scenario
+	)
+
+	// Step 1: Tenant loader pre-configures prefix for "CTL" tenant
+	feeder.SetPrefixFunc("CTL")
+
+	// Verify prefix is set with underscore
+	if feeder.Prefix != "CTL_" {
+		t.Fatalf("Expected prefix 'CTL_' after SetPrefixFunc, got: %s", feeder.Prefix)
+	}
+
+	// Step 2: Config builder calls FeedKey with section name "uploads"
+	// This is the CRITICAL test: prefix should be PRESERVED, not overwritten
+	err := feeder.FeedKey("uploads", uploadConfig)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Step 3: Verify prefix was PRESERVED (not overwritten to "uploads_")
+	if feeder.Prefix != "CTL_" {
+		t.Errorf("CRITICAL: Expected prefix preserved as 'CTL_', but got: %s (this is the bug the PR fixes!)", feeder.Prefix)
+	}
+
+	// Step 4: Verify config was loaded using CTL prefix
+	if uploadConfig.ImageBucket != "ctl-images" {
+		t.Errorf("Expected ImageBucket 'ctl-images', got: %s", uploadConfig.ImageBucket)
+	}
+	if uploadConfig.VideoBucket != "ctl-videos" {
+		t.Errorf("Expected VideoBucket 'ctl-videos', got: %s", uploadConfig.VideoBucket)
+	}
+}
+
+// TestTenantAffixedEnvFeeder_RealWorld_BackwardCompatibility tests that
+// the NEW behavior is still backward compatible with direct FeedKey usage
+func TestTenantAffixedEnvFeeder_RealWorld_BackwardCompatibility(t *testing.T) {
+	// OLD usage pattern: call FeedKey directly without pre-configuring
+	// Should still work by setting prefix from the key parameter
+
+	os.Setenv("MYAPP_SERVICE_URL", "https://myapp.example.com")
+	os.Setenv("MYAPP_SERVICE_PORT", "8080")
+	defer func() {
+		os.Unsetenv("MYAPP_SERVICE_URL")
+		os.Unsetenv("MYAPP_SERVICE_PORT")
+	}()
+
+	type ServiceConfig struct {
+		URL  string `env:"SERVICE_URL"`
+		Port int    `env:"SERVICE_PORT"`
+	}
+
+	serviceConfig := &ServiceConfig{}
+
+	// Create feeder WITHOUT pre-configuring
+	feeder := NewTenantAffixedEnvFeeder(
+		func(tenantId string) string { return tenantId + "_" },
+		func(env string) string { return "" },
+	)
+
+	// Call FeedKey directly (backward compatible usage)
+	// Since prefix and suffix are both empty, they should be set from key
+	err := feeder.FeedKey("MYAPP", serviceConfig)
+	if err != nil {
+		t.Errorf("FeedKey failed: %v", err)
+	}
+
+	// Verify prefix was set from key with underscore
+	if feeder.Prefix != "MYAPP_" {
+		t.Errorf("Expected prefix set to 'MYAPP_', got: %s", feeder.Prefix)
+	}
+
+	// Verify config was loaded
+	if serviceConfig.URL != "https://myapp.example.com" {
+		t.Errorf("Expected URL 'https://myapp.example.com', got: %s", serviceConfig.URL)
+	}
+	if serviceConfig.Port != 8080 {
+		t.Errorf("Expected Port 8080, got: %d", serviceConfig.Port)
+	}
+}

--- a/feeders/unified_catalog_integration_test.go
+++ b/feeders/unified_catalog_integration_test.go
@@ -182,7 +182,7 @@ BASE_PORT=3000
 
 	// Set OS environment variables
 	t.Setenv("OS_OVERRIDE_HOST", "os-host")
-	t.Setenv("PROD__CONFIG__ENV", "production") // For AffixedEnvFeeder
+	t.Setenv("PROD_CONFIG_ENV", "production") // For AffixedEnvFeeder (framework no longer adds underscores)
 
 	type Config struct {
 		BaseHost     string `env:"BASE_HOST"`


### PR DESCRIPTION
…loading

  The TenantAffixedEnvFeeder was failing when used with tenant config loader
  because it tried to set prefix/suffix twice:
  1. Tenant loader pre-configures prefix (e.g., "CTL") before calling Feed()
  2. Config builder calls FeedKey() with section name, which overwrote prefix

  Changes:
  - Feed() now returns nil instead of error when prefix not set (FeedKey will be called next by ComplexFeeder-aware loaders)
  - FeedKey() preserves pre-configured prefix/suffix instead of overwriting (only sets prefix from key parameter if not already configured)

  This fixes tenant-specific environment variable loading where prefixed
  vars like CTL_AWS_IMAGE_UPLOAD_BUCKET were being ignored.